### PR TITLE
Fix sign up form typo

### DIFF
--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -52,7 +52,7 @@ export const actions = {
     return logOut()
   },
 
-  signup(_, credentials) {
+  signUp(_, credentials) {
     return signUp(credentials)
       .then(response => {
         if (response.data.status !== 'success') {

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -19,7 +19,7 @@
         name="email"
         type="text"
         autofocus
-        @keypress.enter="tryToLogIn"
+        @keypress.enter="submit"
       />
 
       <BaseInputText
@@ -28,7 +28,7 @@
         label="Password"
         name="password"
         type="password"
-        @keypress.enter="tryToLogIn"
+        @keypress.enter="submit"
       />
       <div>
         <BaseButton :disabled="processingForm" @click="submit">


### PR DESCRIPTION
Took me an embarrassing amount of time to realize I named my store method `signup` instead of `signUp` 🤦‍♂️

Sign up form works now.