### PR TITLE
Topnav

### DIFF
--- a/src/components/FooterNav.vue
+++ b/src/components/FooterNav.vue
@@ -69,6 +69,7 @@ export default {
   position: fixed;
   bottom: 0;
   width: 100%;
+  display: none;
 }
 
 .footer-container {
@@ -85,9 +86,9 @@ export default {
 }
 
 // TODO: Hide when non-mobile
-// @media (min-width: 768px) {
-//   #footer-nav {
-//     display: none;
-//   }
-// }
+@media (min-width: 100px) and (max-width: 575px) {
+  #footer-nav {
+    display: block;
+  }
+}
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -83,6 +83,9 @@ img {
   .justify-content {
     justify-content: center;
   }
+  .header-container {
+    padding: $spacer * 2;
+  }
 
   .header-img {
     width: 36px;

--- a/src/components/TopNav.vue
+++ b/src/components/TopNav.vue
@@ -1,8 +1,7 @@
 <template>
   <div id="top-nav">
-    <p>LOGO</p>
+    <BaseLink :to="{ name: 'home' }"> LOGO </BaseLink>
     <ul class="top-nav-container">
-      <NavBarRoutes :routes="persistentNavRoutes" />
       <NavBarRoutes v-if="loggedIn" :routes="loggedInNavRoutes" />
       <NavBarRoutes v-else :routes="loggedOutNavRoutes" />
     </ul>
@@ -17,18 +16,6 @@ export default {
   components: { NavBarRoutes },
   data() {
     return {
-      persistentNavRoutes: [
-        {
-          name: 'home',
-          title: 'Home',
-          fontAwesomeClass: 'home',
-        },
-        // {
-        //   name: 'competition',
-        //   params: { id: 1 },
-        //   title: 'Competition',
-        // },
-      ],
       loggedInNavRoutes: [
         {
           name: 'matches',
@@ -67,7 +54,7 @@ export default {
 
 #top-nav {
   background-color: $purple;
-  display: flex;
+  display: none;
   justify-content: space-between;
   align-items: center;
   padding: $spacer;
@@ -100,9 +87,9 @@ export default {
 }
 
 // TODO: Hide when mobile
-// @media (min-width: 768px) {
-//   #footer-nav {
-//     display: none;
-//   }
-// }
+@media (min-width: 576px) {
+  #top-nav {
+    display: flex;
+  }
+}
 </style>

--- a/src/components/TopNav.vue
+++ b/src/components/TopNav.vue
@@ -1,0 +1,108 @@
+<template>
+  <div id="top-nav">
+    <p>LOGO</p>
+    <ul class="top-nav-container">
+      <NavBarRoutes :routes="persistentNavRoutes" />
+      <NavBarRoutes v-if="loggedIn" :routes="loggedInNavRoutes" />
+      <NavBarRoutes v-else :routes="loggedOutNavRoutes" />
+    </ul>
+  </div>
+</template>
+
+<script>
+import { authComputed } from '@/store/helpers'
+import NavBarRoutes from './NavBarRoutes'
+
+export default {
+  components: { NavBarRoutes },
+  data() {
+    return {
+      persistentNavRoutes: [
+        {
+          name: 'home',
+          title: 'Home',
+          fontAwesomeClass: 'home',
+        },
+        // {
+        //   name: 'competition',
+        //   params: { id: 1 },
+        //   title: 'Competition',
+        // },
+      ],
+      loggedInNavRoutes: [
+        {
+          name: 'matches',
+          title: 'Matches',
+          fontAwesomeClass: 'futbol',
+        },
+        {
+          name: 'leaderboards',
+          params: { id: 1 },
+          title: 'Leaderboards',
+          fontAwesomeClass: 'trophy',
+        },
+        {
+          name: 'profile',
+          title: 'Profile',
+          fontAwesomeClass: 'user',
+        },
+      ],
+      loggedOutNavRoutes: [
+        {
+          name: 'login',
+          title: 'Log in',
+          fontAwesomeClass: 'sign-in-alt',
+        },
+      ],
+    }
+  },
+  computed: {
+    ...authComputed,
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles';
+
+#top-nav {
+  background-color: $purple;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: $spacer;
+  color: white;
+  height: 64px;
+  a {
+    opacity: 0.7;
+    margin: $spacer * 2;
+    color: white;
+  }
+  .active {
+    opacity: 1;
+  }
+  a:hover {
+    opacity: 1;
+  }
+}
+
+.top-nav-container {
+  padding: 0 $size-grid-padding;
+  text-align: center;
+  list-style-type: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.5em;
+  a {
+    display: inline-block;
+  }
+}
+
+// TODO: Hide when mobile
+// @media (min-width: 768px) {
+//   #footer-nav {
+//     display: none;
+//   }
+// }
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <TopNav />
     <main>
       <div class="banner">
         <div class="banner-container">
@@ -29,9 +30,10 @@
 <script>
 import FooterNav from '@/components/FooterNav'
 import HomeStep from '@/components/HomeStep'
+import TopNav from '@/components/TopNav'
 
 export default {
-  components: { FooterNav, HomeStep },
+  components: { FooterNav, HomeStep, TopNav },
   data() {
     return {
       steps: [],

--- a/src/views/layouts/DefaultLayout.vue
+++ b/src/views/layouts/DefaultLayout.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="content">
+    <TopNav />
     <Header :title="$route.meta.title" :img="$route.meta.img" />
     <main id="wrapper-main">
       <div class="p-4">
@@ -13,9 +14,10 @@
 <script>
 import Header from '@/components/Header'
 import FooterNav from '@/components/FooterNav'
+import TopNav from '@/components/TopNav'
 
 export default {
-  components: { Header, FooterNav },
+  components: { Header, FooterNav, TopNav },
 }
 </script>
 


### PR DESCRIPTION
showing the correct nav based on screen size
Closes #45 

Mobile: 
<img width="515" alt="Screen Shot 2021-05-27 at 16 35 31" src="https://user-images.githubusercontent.com/25542223/119784843-91ffbf80-bf09-11eb-864f-a00d954ce7e0.png">

Larger Screen:
<img width="1062" alt="Screen Shot 2021-05-27 at 16 36 04" src="https://user-images.githubusercontent.com/25542223/119784922-a479f900-bf09-11eb-9bd7-e2a45df53dcf.png">

It's not perfect. I think words would be better on the top nav. But the other components were already built.