### PR TITLE
Add visual clues for prediction result + logic to disable predictions

### DIFF
--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -5,6 +5,7 @@
         class="w-1/3"
         :team="match.teamHome"
         :status="status('home')"
+        :disabled="disabled"
         @click.native="setPrediction('home')"
       />
       <div
@@ -14,6 +15,7 @@
         <div class="flex-grow">
           <PredictionChoiceDraw
             :status="status('draw')"
+            :disabled="disabled"
             @click.native="setPrediction('draw')"
           />
         </div>
@@ -22,6 +24,7 @@
         class="w-1/3"
         :team="match.teamAway"
         :status="status('away')"
+        :disabled="disabled"
         @click.native="setPrediction('away')"
       />
     </div>
@@ -41,10 +44,16 @@ export default {
       type: Object,
       required: true,
     },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   methods: {
     async setPrediction(choice) {
+      if (this.disabled) return
+
       this.loading = true
       const prediction = await this.$store.dispatch(`matches/setPrediction`, {
         match: this.match,

--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -5,7 +5,7 @@
         class="w-1/3"
         :team="match.teamHome"
         :status="status('home')"
-        :disabled="disabled"
+        :clickable="!disabled"
         @click.native="setPrediction('home')"
       />
       <div
@@ -15,7 +15,7 @@
         <div class="flex-grow">
           <PredictionChoiceDraw
             :status="status('draw')"
-            :disabled="disabled"
+            :clickable="!disabled"
             @click.native="setPrediction('draw')"
           />
         </div>
@@ -24,7 +24,7 @@
         class="w-1/3"
         :team="match.teamAway"
         :status="status('away')"
-        :disabled="disabled"
+        :clickable="!disabled"
         @click.native="setPrediction('away')"
       />
     </div>
@@ -44,9 +44,9 @@ export default {
       type: Object,
       required: true,
     },
-    disabled: {
+    selectable: {
       type: Boolean,
-      default: false,
+      default: true,
     },
   },
 
@@ -95,6 +95,9 @@ export default {
   },
 
   computed: {
+    disabled() {
+      return !this.selectable || this.loading
+    },
     matchDate() {
       if (this.match.status === 'finished') {
         return 'Full Time'

--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="rounded-2xl text-center my-5 mx-2 p-2 bg-white shadow">
+  <div
+    :class="[
+      'rounded-2xl text-center my-5 mx-2 p-2 shadow bg-white transition duration-300',
+      borderStyle,
+    ]"
+  >
     <div class="flex align justify-evenly">
       <PredictionChoiceTeam
         class="w-1/3"
@@ -63,28 +68,9 @@ export default {
       this.loading = false
     },
     status(choice) {
-      // TODO: Remove the next statement once `prediction.correct` has been added to the API
-      if (
-        this.match.status === 'finished' &&
-        'prediction' in this.match &&
-        'choice' in this.match.prediction
-      ) {
-        this.match.prediction.correct =
-          (this.match.prediction.choice === 'draw' &&
-            this.match.teamAway.score === this.match.teamHome.score) ||
-          (this.match.prediction.choice === 'away' &&
-            this.match.teamAway.score > this.match.teamHome.score) ||
-          (this.match.prediction.choice === 'home' &&
-            this.match.teamAway.score < this.match.teamHome.score)
-      }
-      // END
-
-      if (
-        'prediction' in this.match &&
-        this.match.prediction.choice === choice
-      ) {
-        if ('correct' in this.match.prediction) {
-          return this.match.prediction.correct ? 'correct' : 'wrong'
+      if (this.madePrediction && this.match.prediction.choice === choice) {
+        if (this.match.status === 'finished') {
+          return this.correctPrediction ? 'correct' : 'wrong'
         } else {
           return 'selected'
         }
@@ -110,6 +96,35 @@ export default {
           month: 'long',
           day: 'numeric',
         })
+      }
+    },
+    madePrediction() {
+      return 'prediction' in this.match
+    },
+    correctPrediction() {
+      return (
+        this.match.status === 'finished' &&
+        this.madePrediction &&
+        ((this.match.prediction.choice === 'draw' &&
+          this.match.teamAway.score === this.match.teamHome.score) ||
+          (this.match.prediction.choice === 'away' &&
+            this.match.teamAway.score > this.match.teamHome.score) ||
+          (this.match.prediction.choice === 'home' &&
+            this.match.teamAway.score < this.match.teamHome.score))
+      )
+    },
+    borderStyle() {
+      if (this.match.status === 'finished') {
+        // Game finished - Prediction is either right or wrong/missing
+        return this.correctPrediction
+          ? 'border-6 border-badge-correct border-opacity-20'
+          : 'border-6 border-badge-wrong border-opacity-20'
+      } else if (this.match.status === 'upcoming' && !this.madePrediction) {
+        // Game upcoming and no prediction made
+        return 'border-6 border-badge-default'
+      } else {
+        // Game upcoming and prediction already made
+        return null
       }
     },
   },

--- a/src/components/PredictionChoiceDraw.vue
+++ b/src/components/PredictionChoiceDraw.vue
@@ -2,8 +2,8 @@
   <div
     :class="[
       'flex flex-col py-2 px-3 h-full rounded-full shadow-inner-md bg-gray-400',
-      highlight,
-      cursor,
+      highlightStyle,
+      clickableStyle,
     ]"
   >
     <span class="uppercase text-sm leading-none text-white select-none">
@@ -26,10 +26,10 @@ export default {
   },
 
   computed: {
-    highlight() {
+    highlightStyle() {
       return `border-6 border-badge-${this.status}`
     },
-    cursor() {
+    clickableStyle() {
       return this.clickable ? 'cursor-pointer' : 'cursor-default'
     },
   },

--- a/src/components/PredictionChoiceDraw.vue
+++ b/src/components/PredictionChoiceDraw.vue
@@ -3,6 +3,7 @@
     :class="[
       'flex flex-col py-2 px-3 h-full rounded-full shadow-inner-md bg-gray-400',
       highlight,
+      cursor,
     ]"
   >
     <span class="uppercase text-sm leading-none text-white select-none">
@@ -17,13 +18,19 @@ export default {
     status: {
       type: String,
       default: 'default',
-      required: false,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
     },
   },
 
   computed: {
     highlight() {
       return `border-6 border-badge-${this.status}`
+    },
+    cursor() {
+      return this.disabled ? 'cursor-default' : 'cursor-pointer'
     },
   },
 }

--- a/src/components/PredictionChoiceDraw.vue
+++ b/src/components/PredictionChoiceDraw.vue
@@ -19,7 +19,7 @@ export default {
       type: String,
       default: 'default',
     },
-    disabled: {
+    clickable: {
       type: Boolean,
       default: false,
     },
@@ -30,7 +30,7 @@ export default {
       return `border-6 border-badge-${this.status}`
     },
     cursor() {
-      return this.disabled ? 'cursor-default' : 'cursor-pointer'
+      return this.clickable ? 'cursor-pointer' : 'cursor-default'
     },
   },
 }

--- a/src/components/PredictionChoiceTeam.vue
+++ b/src/components/PredictionChoiceTeam.vue
@@ -19,7 +19,7 @@ export default {
       type: String,
       required: false,
     },
-    disabled: {
+    clickable: {
       type: Boolean,
       default: false,
     },
@@ -27,7 +27,7 @@ export default {
 
   computed: {
     cursor() {
-      return this.disabled ? 'cursor-default' : 'cursor-pointer'
+      return this.clickable ? 'cursor-pointer' : 'cursor-default'
     },
   },
 }

--- a/src/components/PredictionChoiceTeam.vue
+++ b/src/components/PredictionChoiceTeam.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['flex flex-col my-2 items-center px-3', cursor]">
+  <div :class="['flex flex-col my-2 items-center px-3', clickableStyle]">
     <p class="uppercase mb-1 h-8 leading-none flex items-center">
       {{ team.name }}
     </p>
@@ -26,8 +26,8 @@ export default {
   },
 
   computed: {
-    cursor() {
-      return this.clickable ? 'cursor-pointer' : 'cursor-default'
+    clickableStyle() {
+      return this.clickable ? 'cursor-pointer' : 'cursor-default opacity-80'
     },
   },
 }

--- a/src/components/PredictionChoiceTeam.vue
+++ b/src/components/PredictionChoiceTeam.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col my-2 items-center px-3">
+  <div :class="['flex flex-col my-2 items-center px-3', cursor]">
     <p class="uppercase mb-1 h-8 leading-none flex items-center">
       {{ team.name }}
     </p>
@@ -18,6 +18,16 @@ export default {
     status: {
       type: String,
       required: false,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  computed: {
+    cursor() {
+      return this.disabled ? 'cursor-default' : 'cursor-pointer'
     },
   },
 }

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -4,7 +4,7 @@
       v-for="match in matches"
       :key="match.id"
       :match="match"
-      :disabled="match.status != 'upcoming'"
+      :selectable="match.status == 'upcoming'"
     />
   </div>
 </template>

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <MatchCard v-for="match in matches" :key="match.id" :match="match" />
+    <MatchCard
+      v-for="match in matches"
+      :key="match.id"
+      :match="match"
+      :disabled="match.status != 'upcoming'"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
Resolves #44 
Resolves #46 

- [x] Allowing to make predictions only before kickoff
- [x] Add bordered colors to show if the prediction was correct or not once the game is finished
