### PR TITLE
preventing long names/emails from overflowing

### DIFF
--- a/src/components/LeaderboardRanking.vue
+++ b/src/components/LeaderboardRanking.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="d-flex ranking w-100 mt-1">
-    <div class="d-flex min-0">
+    <div class="d-flex min-w-0">
       <div class="position w-50">
         <p>{{ ordinalize(position + 1) }}</p>
       </div>
@@ -16,7 +16,7 @@
           class="avatar"
         />
       </div>
-      <div class="name w-100"> {{ user.name }}</div>
+      <div class="name w-100 truncate"> {{ user.name }}</div>
     </div>
     <div class="points w-50"> {{ user.points }}</div>
   </div>
@@ -64,10 +64,6 @@ export default {
   border-radius: 16px;
 }
 
-.min-0 {
-  min-width: 0;
-}
-
 .w-50 {
   width: 50px;
   text-align: center;
@@ -109,9 +105,6 @@ export default {
 .name {
   font-weight: lighter;
   padding-left: 8px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .points {

--- a/src/components/LeaderboardRanking.vue
+++ b/src/components/LeaderboardRanking.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="d-flex ranking w-100 mt-1">
-    <div class="d-flex">
+    <div class="d-flex min-0">
       <div class="position w-50">
         <p>{{ ordinalize(position + 1) }}</p>
       </div>
@@ -64,6 +64,10 @@ export default {
   border-radius: 16px;
 }
 
+.min-0 {
+  min-width: 0;
+}
+
 .w-50 {
   width: 50px;
   text-align: center;
@@ -105,6 +109,9 @@ export default {
 .name {
   font-weight: lighter;
   padding-left: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .points {


### PR DESCRIPTION
preventing long names/emails from overflowing

*Now:*
<img width="407" alt="Screen Shot 2021-05-29 at 14 35 37" src="https://user-images.githubusercontent.com/25542223/120059241-247b9c80-c08b-11eb-8ff6-e0b9aeaa3179.png">

*Prev:*
<img width="403" alt="Screen Shot 2021-05-29 at 14 36 23" src="https://user-images.githubusercontent.com/25542223/120059255-407f3e00-c08b-11eb-93eb-d82984e59397.png">
