### PR TITLE
A user can update their display name

### DIFF
--- a/src/api/repositories/users.js
+++ b/src/api/repositories/users.js
@@ -4,7 +4,9 @@ export default {
   getUser(userId) {
     return Repository.get(`/users/${userId}`)
   },
-  patchUser(userId) {
-    return Repository.patch(`/users/${userId}`)
+  patchUser(userId, name) {
+    return Repository.patch(`/users/${userId}`, {
+      user: { name: name },
+    })
   },
 }

--- a/src/api/repositories/users.js
+++ b/src/api/repositories/users.js
@@ -4,4 +4,7 @@ export default {
   getUser(userId) {
     return Repository.get(`/users/${userId}`)
   },
+  patchUser(userId) {
+    return Repository.patch(`/users/${userId}`)
+  },
 }

--- a/src/store/modules/users.js
+++ b/src/store/modules/users.js
@@ -35,4 +35,11 @@ export const actions = {
       return user
     })
   },
+  patchUser({ commit }, { userId, name } = {}) {
+    return UsersRepository.patchUser(userId, name).then(response => {
+      const user = response.data
+      commit('CACHE_USER', user)
+      return user
+    })
+  },
 }

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -1,6 +1,18 @@
 <template>
   <div>
     <div>
+      <p>Email</p>
+      <!-- Not sure how to give a default value -->
+      <BaseInputText
+        v-model="name"
+        label="Name"
+        name="name"
+        type="text"
+        disabled="true"
+        :value="user.email"
+        autofocus
+        @keypress.enter="submit"
+      />
       <p>Display Name</p>
       <div class="flex">
         <BaseInputText

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -1,38 +1,42 @@
 <template>
   <div>
-    <div>
-      <p>Email</p>
-      <!-- Not sure how to give a default value -->
-      <BaseInputText
-        v-model="user.email"
-        label="Email"
-        name="email"
-        type="text"
-        disabled="true"
-        :value="user.email"
-        autofocus
-        @keypress.enter="submit"
-      />
-      <p>Display Name</p>
-      <div class="flex">
+    <div class="flex flex-col justify-center items-center">
+      <div class="w-full md:w-6/12">
+        <p>Email</p>
+        <!-- Not sure how to give a default value -->
         <BaseInputText
-          v-model="name"
-          label="Name"
-          name="name"
+          v-model="user.email"
+          label="Email"
+          name="email"
           type="text"
+          disabled="true"
+          :value="user.email"
           autofocus
           @keypress.enter="submit"
         />
-        <div>
-          <BaseButton :disabled="processingForm" @click="submit">
-            Update
-          </BaseButton>
+        <p>Display Name</p>
+        <div class="flex">
+          <BaseInputText
+            v-model="name"
+            label="Name"
+            name="name"
+            type="text"
+            autofocus
+            @keypress.enter="submit"
+          />
+          <div>
+            <BaseButton :disabled="processingForm" @click="submit">
+              Update
+            </BaseButton>
+          </div>
+        </div>
+        <div class="flex items-start w-full">
+          <BaseLink :to="{ name: 'logout' }">
+            <p>Log out <BaseIcon name="sign-out-alt" /></p>
+          </BaseLink>
         </div>
       </div>
     </div>
-    <BaseLink :to="{ name: 'logout' }">
-      <p>Log out <BaseIcon name="sign-out-alt" /></p>
-    </BaseLink>
   </div>
 </template>
 

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -1,19 +1,21 @@
 <template>
   <div>
     <div>
-      <p>Name</p>
-      <BaseInputText
-        v-model="name"
-        label="Name"
-        name="name"
-        type="text"
-        autofocus
-        @keypress.enter="submit"
-      />
-      <div>
-        <BaseButton :disabled="processingForm" @click="submit">
-          Create
-        </BaseButton>
+      <p>Display Name</p>
+      <div class="flex">
+        <BaseInputText
+          v-model="name"
+          label="Name"
+          name="name"
+          type="text"
+          autofocus
+          @keypress.enter="submit"
+        />
+        <div>
+          <BaseButton :disabled="processingForm" @click="submit">
+            Update
+          </BaseButton>
+        </div>
       </div>
     </div>
     <BaseLink :to="{ name: 'logout' }">
@@ -47,7 +49,7 @@ export default {
 
   methods: {
     ...mapActions({
-      postLeaderboard: 'users/patchUser',
+      patchUser: 'users/patchUser',
     }),
     async fetchUser() {
       this.loading = true
@@ -62,9 +64,9 @@ export default {
         userId: this.user.id,
         name: this.name,
       }
-      await this.patchUser(formData)
+      this.user = await this.patchUser(formData)
       this.processingForm = false
-      this.$router.push(this.$route.query.redirectFrom || { name: 'profile' })
+      // show success?
     },
   },
 }

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -38,6 +38,7 @@ export default {
 
   data() {
     return {
+      name: '',
       loading: false,
       processingForm: false,
       user: null,
@@ -46,7 +47,7 @@ export default {
 
   methods: {
     ...mapActions({
-      postLeaderboard: 'leaderboards/postLeaderboard',
+      postLeaderboard: 'users/patchUser',
     }),
     async fetchUser() {
       this.loading = true
@@ -58,14 +59,12 @@ export default {
     async submit() {
       this.processingForm = true
       const formData = {
-        competitionId: this.competitionId,
+        userId: this.user.id,
         name: this.name,
       }
-      await this.postLeaderboard(formData)
+      await this.patchUser(formData)
       this.processingForm = false
-      this.$router.push(
-        this.$route.query.redirectFrom || { name: 'leaderboards' }
-      )
+      this.$router.push(this.$route.query.redirectFrom || { name: 'profile' })
     },
   },
 }

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -4,7 +4,7 @@
       <p>Email</p>
       <!-- Not sure how to give a default value -->
       <BaseInputText
-        v-model="email"
+        v-model="user.email"
         label="Email"
         name="email"
         type="text"
@@ -53,6 +53,7 @@ export default {
   data() {
     return {
       name: '',
+      email: '',
       loading: false,
       processingForm: false,
       user: null,
@@ -77,6 +78,7 @@ export default {
         name: this.name,
       }
       this.user = await this.patchUser(formData)
+      this.name = this.user.name
       this.processingForm = false
       // show success?
     },

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -1,7 +1,21 @@
 <template>
   <div>
-    <h1>User #{{ id }}</h1>
-    <p>{{ user }}</p>
+    <div>
+      <p>Name</p>
+      <BaseInputText
+        v-model="name"
+        label="Name"
+        name="name"
+        type="text"
+        autofocus
+        @keypress.enter="submit"
+      />
+      <div>
+        <BaseButton :disabled="processingForm" @click="submit">
+          Create
+        </BaseButton>
+      </div>
+    </div>
     <BaseLink :to="{ name: 'logout' }">
       <p>Log out <BaseIcon name="sign-out-alt" /></p>
     </BaseLink>
@@ -9,6 +23,7 @@
 </template>
 
 <script>
+import { mapActions } from 'vuex'
 export default {
   props: {
     id: {
@@ -24,11 +39,15 @@ export default {
   data() {
     return {
       loading: false,
+      processingForm: false,
       user: null,
     }
   },
 
   methods: {
+    ...mapActions({
+      postLeaderboard: 'leaderboards/postLeaderboard',
+    }),
     async fetchUser() {
       this.loading = true
       this.user = await this.$store.dispatch('users/fetchUser', {
@@ -36,6 +55,25 @@ export default {
       })
       this.loading = false
     },
+    async submit() {
+      this.processingForm = true
+      const formData = {
+        competitionId: this.competitionId,
+        name: this.name,
+      }
+      await this.postLeaderboard(formData)
+      this.processingForm = false
+      this.$router.push(
+        this.$route.query.redirectFrom || { name: 'leaderboards' }
+      )
+    },
   },
 }
 </script>
+
+<style lang="scss" scoped>
+@import '@/styles';
+p {
+  color: $purple;
+}
+</style>

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -4,9 +4,9 @@
       <p>Email</p>
       <!-- Not sure how to give a default value -->
       <BaseInputText
-        v-model="name"
-        label="Name"
-        name="name"
+        v-model="email"
+        label="Email"
+        name="email"
         type="text"
         disabled="true"
         :value="user.email"


### PR DESCRIPTION
⚠️ You [need this code](https://github.com/dmbf29/predictor-api/pull/40/files) on your API in order to update a user

## A user can update their display name
<img width="393" alt="Screen Shot 2021-05-30 at 12 41 17" src="https://user-images.githubusercontent.com/25542223/120091751-02485400-c149-11eb-8476-1b654c673463.png">


Two small bugs 🐛 
1. After update and when the profile page is refreshed, it looks like the current user is coming from the previously cached version or root auth version.
<img width="392" alt="Screen Shot 2021-05-30 at 12 41 07" src="https://user-images.githubusercontent.com/25542223/120091765-0eccac80-c149-11eb-9298-15e2bfde1a25.png">

2. ~~No idea on how to pass a default value into the input~~
<img width="395" alt="Screen Shot 2021-05-30 at 13 12 46" src="https://user-images.githubusercontent.com/25542223/120091791-3de31e00-c149-11eb-9ec5-3e1e377c8346.png">
