### PR TITLE
Fix/join routes

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -2,11 +2,12 @@
   <div class="header-container">
     <div class="d-flex justify-content-center">
       <img
+        v-if="img"
         alt="football graphic"
         :src="require('../assets/' + img)"
         class="header-img"
       />
-      <h1> {{ title }}</h1>
+      <h1 v-if="title"> {{ title }}</h1>
     </div>
     <slot />
   </div>
@@ -17,11 +18,11 @@ export default {
   props: {
     title: {
       type: String,
-      required: true,
+      required: false,
     },
     img: {
       type: String,
-      required: true,
+      required: false,
     },
   },
 }

--- a/src/components/LeaderboardSubHeader.vue
+++ b/src/components/LeaderboardSubHeader.vue
@@ -7,7 +7,7 @@
         @click.native="selectLeaderboard(previousLeaderboard.id)"
       />
     </div>
-    <h3> {{ leaderboard.name }} </h3>
+    <h3 v-if="leaderboard"> {{ leaderboard.name }} </h3>
     <div class="mx-5">
       <BaseIcon
         name="angle-right"

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -46,27 +46,14 @@ export default [
       {
         path: '/join/:password',
         name: 'join',
-        component: () => import('@/views/Leaderboards'),
-        props: route => ({
-          competitionId: 1,
-          password: route.params.password,
-        }),
         meta: {
-          title: 'Leaderboards',
-          img: 'trophy.png',
-          subHeader: 'LeaderboardSubHeader',
-          beforeResolve(routeTo, routeFrom, next) {
-            if (store.getters['auth/loggedIn']) {
-              console.log(routeTo.params)
-              // this doesn't work so moved it to "beforeRouteEnter"
-              this.$store.dispatch(
-                'leaderboards/joinLeaderboard',
-                routeTo.params
-              )
-              next({ name: 'leaderboards', params: { competitionId: 1 } })
-            } else {
-              next({ name: 'login' })
-            }
+          authRequired: true, // Router will check auth and redirect here after login
+          async beforeResolve(routeTo, _, next) {
+            await store.dispatch(
+              'leaderboards/joinLeaderboard',
+              routeTo.params.password
+            )
+            next({ name: 'leaderboards', params: { id: 1 } })
           },
         },
       },

--- a/src/store/modules/leaderboards.js
+++ b/src/store/modules/leaderboards.js
@@ -51,18 +51,12 @@ export const mutations = {
 }
 
 export const actions = {
-  fetchLeaderboards({ commit }, competitionId) {
+  fetchLeaderboards({ commit, getters }, competitionId) {
     return LeaderboardsRepository.getLeaderboards(competitionId).then(
       response => {
         commit('SET_LEADERBOARDS', response.data)
-        // check if deleted board is set as selected or non existant
-        if (
-          (window.localStorage.currentLeaderboardId === undefined &&
-            response.data.length > 0) ||
-          !JSON.parse(window.localStorage.leaderboards)
-            .map(l => l.id)
-            .includes(parseInt(window.localStorage.currentLeaderboardId))
-        ) {
+        // check if current board exists
+        if (!getters.currentLeaderboard && response.data.length > 0) {
           commit('SET_CURRENT_LEADERBOARD_ID', response.data[0].id)
         }
         return response.data
@@ -75,7 +69,6 @@ export const actions = {
     return leaderboardId
   },
   joinLeaderboard({ commit }, password) {
-    console.log('in store...')
     return LeaderboardsRepository.joinLeaderboard(password).then(response => {
       commit('SET_CURRENT_LEADERBOARD_ID', response.data.id)
       return response.data

--- a/src/views/Leaderboards.vue
+++ b/src/views/Leaderboards.vue
@@ -14,8 +14,6 @@
 <script>
 import LeaderboardCard from '@/components/LeaderboardCard'
 import { mapGetters, mapActions } from 'vuex'
-// I read this may cause problems...
-import store from '@/store'
 // mapGetters is used to import Getters from your store into your component
 // There are also similar mapState, mapActions, mapMutations methods.
 
@@ -32,21 +30,6 @@ export default {
       type: Number,
       required: false,
     },
-  },
-  beforeRouteEnter(to, _from, next) {
-    console.log(to.params)
-    if (to.params.password) {
-      store.dispatch('leaderboards/joinLeaderboard', to.params.password)
-      // this doesn't seem to be working either
-      next({
-        name: 'leaderboards',
-      })
-      // don't have access to "this"
-      // this.$router.push({
-      //   name: 'home',
-      //   params: { competitionId: leaderboard.competition_id },
-      // })
-    }
   },
 
   async mounted() {

--- a/src/views/layouts/DefaultLayout.vue
+++ b/src/views/layouts/DefaultLayout.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="content">
     <TopNav />
-    <Header :title="$route.meta.title" :img="$route.meta.img">
-      <component :is="$route.meta.subHeader" />
+    <Header :title="title" :img="img">
+      <component v-if="subHeader" :is="subHeader" />
     </Header>
     <main id="wrapper-main">
       <div class="p-4">
@@ -21,11 +21,20 @@ import LeaderboardSubHeader from '@/components/LeaderboardSubHeader'
 import MatchesSubHeader from '@/components/MatchesSubHeader'
 
 export default {
-  components: { Header, FooterNav, TopNav, LeaderboardSubHeader, MatchesSubHeader },
+  components: {
+    Header,
+    FooterNav,
+    TopNav,
+    LeaderboardSubHeader,
+    MatchesSubHeader,
+  },
   data() {
     return {
       leaderboards: [],
       leaderboard: null,
+      title: this.$route.meta.title,
+      img: this.$route.meta.img,
+      subHeader: this.$route.meta.subHeader,
     }
   },
 }


### PR DESCRIPTION
You were basically missing the `async` and `await store.dispatch` in the `beforeResolve`.

I've done some extra refactoring to fix bugs related to edge cases when missing a `currentLeaderboard`.

This is the commit for fixing the `join` route:
https://github.com/trouni/predictor-vue/pull/67/commits/01ce9e8c072e858aba5aae0467cc44cdc83e352c