### PR TITLE
Scroll content in default layout

### DIFF
--- a/src/views/layouts/DefaultLayout.vue
+++ b/src/views/layouts/DefaultLayout.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="content">
+  <div class="content h-screen">
     <TopNav />
     <Header :title="title" :img="img">
       <component v-if="subHeader" :is="subHeader" />
     </Header>
-    <main id="wrapper-main">
+    <main id="wrapper-main" class="overflow-y-auto">
       <div class="p-4 pb-12">
         <RouterView :key="$route.fullPath"></RouterView>
       </div>


### PR DESCRIPTION
This fixes the header to the top of the page.

The content scrolls within the main container of the DefaultLayout