### PR TITLE
Fix/competition routes

### DIFF
--- a/src/api/repositories/competitions.js
+++ b/src/api/repositories/competitions.js
@@ -1,7 +1,7 @@
 import Repository from './repository'
 
 export default {
-  getCompetition(competitionId) {
-    return Repository.get(`/competitions/${competitionId}`)
+  getCompetitions() {
+    return Repository.get(`/competitions/`)
   },
 }

--- a/src/components/FooterNav.vue
+++ b/src/components/FooterNav.vue
@@ -30,13 +30,12 @@ export default {
       ],
       loggedInNavRoutes: [
         {
-          name: 'matches',
+          path: '/matches',
           title: 'Matches',
           fontAwesomeClass: 'futbol',
         },
         {
-          name: 'leaderboards',
-          params: { id: 1 },
+          path: '/leaderboards',
           title: 'Leaderboards',
           fontAwesomeClass: 'trophy',
         },

--- a/src/components/PredictionSwiper.vue
+++ b/src/components/PredictionSwiper.vue
@@ -64,7 +64,7 @@ export default {
       setTimeout(() => {
         this.choice = ''
         if (this.currentMatch) this.statusMatch = this.currentMatch
-        else this.$router.push({ name: 'matches' })
+        else this.$router.push({ path: '/matches' })
       }, 1000)
     },
     async setPrediction(choice) {

--- a/src/components/PredictionSwiperStatus.vue
+++ b/src/components/PredictionSwiperStatus.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script>
-import capitalize from '@/utils/helpers'
+import { capitalize } from '@/utils/helpers'
 import TeamBadge from '@/components/TeamBadge'
 
 export default {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,12 +13,16 @@ const router = new VueRouter({
 })
 
 // Before each route evaluates...
-router.beforeEach((routeTo, routeFrom, next) => {
+router.beforeEach(async (routeTo, routeFrom, next) => {
   // If this isn't an initial page load...
   if (routeFrom.name !== null) {
     // Start the route progress bar.
     NProgress.start()
   }
+
+  // Fetch competitions if missing
+  if (!store.getters['competitions/currentCompetition'])
+    await store.dispatch('competitions/fetchCompetitions')
 
   // Check if auth is required on this route
   // (including nested routes).

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -51,11 +51,14 @@ export default [
         meta: {
           authRequired: true, // Router will check auth and redirect here after login
           async beforeResolve(routeTo, _, next) {
-            await store.dispatch(
+            const membership = await store.dispatch(
               'leaderboards/joinLeaderboard',
               routeTo.params.password
             )
-            next({ name: 'leaderboards', params: { id: 1 } })
+            next({
+              name: 'leaderboards',
+              params: { id: membership.competitionId },
+            })
           },
         },
       },

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -63,73 +63,72 @@ export default [
         },
       },
       {
-        path: '/competitions/:id',
+        path: '/competitions/:id?',
         name: 'competition',
         component: () => import('@/views/Competition'),
-        props: route => ({ id: parseInt(route.params.id) }),
         meta: {
           title: 'Competitions',
+          beforeResolve(routeTo, _routeFrom, next) {
+            if (routeTo.params.id) {
+              store.dispatch(
+                'competitions/selectCompetition',
+                parseInt(routeTo.params.id)
+              )
+              next({ path: routeTo.path.replace(/\/competitions\/\d+/, '') })
+            }
+          },
         },
         children: [
           {
             path: 'leaderboards',
             name: 'leaderboards',
             component: () => import('@/views/Leaderboards'),
-            props: route => ({
-              competitionId: parseInt(route.params.id),
-              leaderboardId: parseInt(
-                store.getters['leaderboards/currentLeaderboard']
-              ),
-            }),
             meta: {
               authRequired: true,
               title: 'Leaderboards',
               img: 'trophy.png',
               subHeader: 'LeaderboardSubHeader',
             },
+            alias: '/leaderboards',
           },
           {
             path: 'predictions',
             name: 'predictions',
             component: () => import('@/views/PredictionsNew'),
-            props: route => ({
-              competitionId: parseInt(route.params.id),
-            }),
             meta: {
               authRequired: true,
               title: 'Predictions',
               img: 'trophy.png',
             },
+            alias: '/predictions',
           },
           {
             path: 'leaderboards/new',
             name: 'new_leaderboard',
             component: () => import('@/views/LeaderboardNew'),
-            props: route => ({
-              competitionId: parseInt(route.params.id),
-            }),
             meta: {
               authRequired: true,
               title: 'New Leaderboard',
               img: 'trophy.png',
             },
+            alias: '/leaderboards/new',
+          },
+          {
+            path: 'matches',
+            name: 'matches',
+            component: () => import('@/views/Matches'),
+            props: route => ({
+              userId: parseInt(route.query.userId) || undefined,
+            }),
+            meta: {
+              authRequired: true,
+              title: store.getters['competitions/currentCompetition'].name,
+              img: 'football.png',
+              subHeader: 'MatchesSubHeader',
+            },
+            alias: '/matches',
           },
         ],
-      },
-      {
-        path: '/matches',
-        name: 'matches',
-        component: () => import('@/views/Matches'),
-        props: route => ({
-          competitionId: parseInt(route.query.competitionId) || undefined,
-          userId: parseInt(route.query.userId) || undefined,
-        }),
-        meta: {
-          authRequired: true,
-          title: 'Euro Championship',
-          img: 'football.png',
-          subHeader: 'MatchesSubHeader',
-        },
       },
       {
         path: '/leaderboards/:id',

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -1,4 +1,5 @@
 import { logIn, logOut, signUp } from '@/api/auth'
+import { saveState, getSavedState } from '@/utils/helpers'
 
 export const state = {
   currentUser: getSavedState('auth.currentUser'),
@@ -68,17 +69,4 @@ export const actions = {
         throw error.response.data.errors
       })
   },
-}
-
-// ===
-// Private helpers
-// ===
-
-function getSavedState(key) {
-  return JSON.parse(window.localStorage.getItem(key))
-}
-
-function saveState(key, state) {
-  if (state) window.localStorage.setItem(key, JSON.stringify(state))
-  else window.localStorage.removeItem(key)
 }

--- a/src/store/modules/competitions.js
+++ b/src/store/modules/competitions.js
@@ -1,21 +1,56 @@
 import { RepositoryFactory } from '@/api/repository-factory'
 const CompetitionsRepository = RepositoryFactory.get('competitions')
+import { saveState, getSavedState } from '@/utils/helpers'
 
 export const state = {
   cached: [],
+  competitions: getSavedState('competitions'),
+  currentCompetitionId: getSavedState('currentCompetitionId'),
 }
 
-export const getters = {}
+export const getters = {
+  competitions(state) {
+    return state.competitions || []
+  },
+  currentCompetition(_, getters) {
+    return getters.competitions.find(
+      competition => competition.id === getters.currentCompetitionId
+    )
+  },
+  competitionsCount(_, getters) {
+    return getters.competitions.length
+  },
+  currentCompetitionId(state, getters) {
+    if (getters.competitionsCount === 0) return null
 
-export const mutations = {}
+    return state.currentCompetitionId || getters.competitions[0].id
+  },
+}
+
+export const mutations = {
+  SET_CURRENT_COMPETITION_ID(state, newValue) {
+    state.currentCompetitionId = newValue
+    saveState('currentCompetitionId', newValue)
+  },
+  SET_COMPETITIONS(state, newValue) {
+    state.competitions = newValue
+    saveState('competitions', newValue)
+  },
+}
 
 export const actions = {
-  fetchCompetitions() {
-    return CompetitionsRepository.get().then(response => response.data)
+  fetchCompetitions({ dispatch, commit, state }) {
+    return CompetitionsRepository.getCompetitions().then(response => {
+      commit('SET_COMPETITIONS', response.data)
+      if (!state.currentCompetitionId && response.data.length > 0) {
+        dispatch('selectCompetition', response.data[0].id)
+      }
+      return response.data
+    })
   },
-  fetchCompetition(_, competitionId) {
-    return CompetitionsRepository.getCompetition(competitionId).then(
-      response => response.data
-    )
+
+  selectCompetition({ commit }, competitionId) {
+    commit('SET_CURRENT_COMPETITION_ID', competitionId)
+    return competitionId
   },
 }

--- a/src/store/modules/matches.js
+++ b/src/store/modules/matches.js
@@ -10,7 +10,12 @@ export const getters = {}
 export const mutations = {}
 
 export const actions = {
-  fetchMatches(_, filters) {
+  fetchMatches({ rootGetters }, { competitionId, userId } = {}) {
+    const filters = {
+      competitionId:
+        competitionId || rootGetters['competitions/currentCompetition'].id,
+    }
+    if (userId) filters['userId'] = userId
     return MatchesRepository.get(filters).then(response => response.data)
   },
   setPrediction(_, { match, choice }) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,3 +1,12 @@
-export default function capitalize(string) {
+export function capitalize(string) {
   return string.charAt(0).toUpperCase() + string.slice(1)
+}
+
+export function saveState(key, state) {
+  if (state) window.localStorage.setItem(key, JSON.stringify(state))
+  else window.localStorage.removeItem(key)
+}
+
+export function getSavedState(key) {
+  return JSON.parse(window.localStorage.getItem(key))
 }

--- a/src/views/Competition.vue
+++ b/src/views/Competition.vue
@@ -1,17 +1,15 @@
 <template>
   <div>
     <div v-if="$route.name === 'competition'">
-      <BaseLink :to="{ name: 'leaderboards', params: { competitionId: id } }">
+      <BaseLink :to="{ name: 'leaderboards' }">
         <BaseButton>View Leaderboards</BaseButton>
       </BaseLink>
 
-      <BaseLink :to="{ name: 'matches', query: { competitionId: id } }">
+      <BaseLink :to="{ name: 'matches' }">
         <BaseButton>View Matches</BaseButton>
       </BaseLink>
 
-      <BaseLink
-        :to="{ name: 'new_leaderboard', params: { competitionId: id } }"
-      >
+      <BaseLink :to="{ name: 'new_leaderboard' }">
         <BaseButton>New Leaderboard</BaseButton>
       </BaseLink>
     </div>
@@ -21,15 +19,7 @@
 </template>
 
 <script>
-export default {
-  props: {
-    id: {
-      type: Number,
-      default: null,
-      required: true,
-    },
-  },
-}
+export default {}
 </script>
 
 <style scoped>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,7 +9,7 @@
           <div class="mt-3">
             <BaseButton>
               <BaseLink
-                :to="{ name: 'matches' }"
+                :to="{ path: '/matches' }"
                 v-if="$store.getters['auth/loggedIn']"
               >
                 Matches

--- a/src/views/LeaderboardNew.vue
+++ b/src/views/LeaderboardNew.vue
@@ -21,13 +21,6 @@
 import { mapActions } from 'vuex'
 
 export default {
-  props: {
-    competitionId: {
-      type: Number,
-      default: null,
-      required: true,
-    },
-  },
   data() {
     return {
       name: '',
@@ -42,7 +35,6 @@ export default {
     async submit() {
       this.processingForm = true
       const formData = {
-        competitionId: this.competitionId,
         name: this.name,
       }
       await this.postLeaderboard(formData)

--- a/src/views/Leaderboards.vue
+++ b/src/views/Leaderboards.vue
@@ -23,11 +23,6 @@ export default {
   components: { LeaderboardCard, LeaderboardActions },
 
   props: {
-    competitionId: {
-      type: Number,
-      default: 1,
-      required: false,
-    },
     userId: {
       type: Number,
       required: false,
@@ -35,7 +30,7 @@ export default {
   },
 
   async mounted() {
-    this.fetchLeaderboards(this.competitionId)
+    this.fetchLeaderboards()
   },
 
   // The state is managed from the store, we don't want to be reassigning these variables

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -5,7 +5,7 @@
         v-if="missingPredictions.length"
         class="uppercase text-center m-5"
       >
-        <BaseLink :to="{ name: 'predictions' }" :params="{ id: 1 }">
+        <BaseLink :to="{ name: 'predictions' }">
           Make your predictions
         </BaseLink>
       </BaseButton>
@@ -26,11 +26,6 @@ export default {
   components: { MatchesGrouping },
 
   props: {
-    competitionId: {
-      type: Number,
-      default: 1,
-      required: false,
-    },
     userId: {
       type: Number,
       required: false,
@@ -75,10 +70,9 @@ export default {
   methods: {
     async fetchMatches() {
       this.loading = true
-      const filters = {}
-      if (this.userId) filters['userId'] = this.userId
-      if (this.competitionId) filters['competitionId'] = this.competitionId
-      this.matches = await this.$store.dispatch('matches/fetchMatches', filters)
+      this.matches = await this.$store.dispatch('matches/fetchMatches', {
+        userId: this.userId,
+      })
       this.loading = false
     },
   },

--- a/src/views/PredictionsNew.vue
+++ b/src/views/PredictionsNew.vue
@@ -8,14 +8,6 @@ import PredictionSwiper from '@/components/PredictionSwiper'
 export default {
   components: { PredictionSwiper },
 
-  props: {
-    competitionId: {
-      type: Number,
-      default: 1,
-      required: false,
-    },
-  },
-
   async mounted() {
     this.fetchMatches()
   },
@@ -38,9 +30,7 @@ export default {
   methods: {
     async fetchMatches() {
       this.loading = true
-      this.matches = await this.$store.dispatch('matches/fetchMatches', {
-        competitionId: this.competitionId,
-      })
+      this.matches = await this.$store.dispatch('matches/fetchMatches')
       this.loading = false
     },
   },


### PR DESCRIPTION
You will need [this code](https://github.com/dmbf29/predictor-api/pull/53) and [this code](https://github.com/dmbf29/predictor-api/pull/54) from the API.

Sorry, many files were touched here.
It's a big refactor to remove a lot of the complexity from the competition id in our FE.

## Context
So, as I was fixing some of the competitions related routes and bugs, I realized that just having that `competitionId` everywhere was adding significant complexity and potential for bugs for pretty much zero value at this stage (my fault for pushing the option of seeing multiple competitions at the same time in the first place).

I've decided to make a large refactor to remove that complexity:
1. I've removed the `competitionId` from all the components.
2. The current competition is now set in the store, following a similar logic to the leaderboards
3. Created aliased routes so that the routes also drop the need for a `competitionId` (following the idea that components don't need it) and removed all the associated props (i.e. `/competitions/:id/leaderboards` => `/leaderboards`)
4. I kept the original nested routes (e.g. `competitions/:id/leaderboards`) which allows us to navigate to a page and reassign the `currentCompetitionId` at the same time. In other words, if you visit `competitions/34/leaderboards`, it will first set the `currentCompetitionId` to 34 in the store, then redirect you to `/leaderboards`
5. For now, the default `currentCompetitionId` is the first one from all the competitions. It is then persisted in the localStorage. In the future, we could imagine also storing that in the User model if there are multiple competitions running at the same time and the user wants to switch.

Not perfect, but removing the `competitionId` from the components and all FE routes should reduce the surface area for potential bugs when loading components or linking to other pages.