### PR TITLE
Fix close action

### DIFF
--- a/src/components/ConfirmDelete.vue
+++ b/src/components/ConfirmDelete.vue
@@ -65,13 +65,13 @@
             >
               Delete
             </button>
-            <!-- <button
+            <button
               type="button"
               @click="close"
               class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
             >
               Cancel
-            </button> -->
+            </button>
           </div>
         </div>
       </div>
@@ -93,9 +93,9 @@ export default {
   },
   methods: {
     // TODO: Uncomment button when the close works
-    // close() {
-    //   this.$emit('closeModal')
-    // },
+    close() {
+      this.$emit('closeModal')
+    },
     deleteRecord() {
       this.$emit('deleteRecordEvent')
     },

--- a/src/components/LeaderboardAction.vue
+++ b/src/components/LeaderboardAction.vue
@@ -7,16 +7,16 @@
       v-else-if="action === 'invite'"
       :password="leaderboard.password"
     />
-    <div v-else-if="action === 'leave'" @click="showModal = !showModal"
+    <div v-else-if="action === 'leave'" @click="showModal = true"
       ><span class="mr-1">{{ text }} </span><BaseIcon :name="icon" />
-      <ConfirmDelete
-        v-show="showModal"
-        modalHeadline="Leave this leaderboard?"
-        deleteMessage="You will need an invite link to rejoin."
-        @deleteRecordEvent="leave"
-        @closeModal="closeModal"
-      ></ConfirmDelete>
     </div>
+    <ConfirmDelete
+      v-if="showModal"
+      modalHeadline="Leave this leaderboard?"
+      deleteMessage="You will need an invite link to rejoin."
+      @deleteRecordEvent="leave"
+      @closeModal="closeModal"
+    ></ConfirmDelete>
   </div>
 </template>
 


### PR DESCRIPTION
Fixed it, I realized the `@click` was on the parent div of the modal. Everytime you clicked on the modal, it actually set the `showModal` back to true. Moving the `ConfirmDelete` modal outside of the div with the `@click` solved it.

The `LeaderboardAction` component is a bit complex and has technically different components in there (`Invite`, `New` or `Leave` are each doing different things) and it makes it difficult to hide the `Leave` action when there is no leaderboard for example (while still showing the `+New`). I would suggest to have these in separate components for a future refactor.