### PR TITLE
Feature: show predictions from other users

### DIFF
--- a/src/api/repositories/users.js
+++ b/src/api/repositories/users.js
@@ -1,8 +1,8 @@
 import Repository from './repository'
 
 export default {
-  getUser(userId) {
-    return Repository.get(`/users/${userId}`)
+  getUser(userId, { competitionId } = {}) {
+    return Repository.get(`/users/${userId}`, { params: { competitionId } })
   },
   patchUser(userId, name, photoKey) {
     return Repository.patch(`/users/${userId}`, {

--- a/src/components/LeaderboardCard.vue
+++ b/src/components/LeaderboardCard.vue
@@ -5,6 +5,7 @@
       :key="user.id"
       :user="user"
       :position="index"
+      :link-predictions="true"
     />
   </div>
 </template>

--- a/src/components/LeaderboardRanking.vue
+++ b/src/components/LeaderboardRanking.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="d-flex ranking w-100 mt-1">
     <div class="d-flex min-w-0">
-      <div class="position w-50">
+      <div v-if="position !== null" class="position w-50">
         <p>{{ ordinalize(position + 1) }}</p>
       </div>
       <!-- <div class="direction w-50">
@@ -32,7 +32,13 @@
           />
         </div>
       </div>
-      <div class="name w-100 truncate"> {{ user.name }}</div>
+      <BaseLink
+        :to="{ path: '/matches', query: { userId: user.userId } }"
+        :disabled="!linkPredictions"
+        class="name w-100 truncate"
+      >
+        {{ user.name }}
+      </BaseLink>
     </div>
     <div class="points w-50"> {{ user.points }}</div>
   </div>
@@ -49,6 +55,11 @@ export default {
     },
     position: {
       type: Number,
+      default: null,
+    },
+    linkPredictions: {
+      type: Boolean,
+      default: false,
     },
   },
   components: {

--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -40,7 +40,7 @@
 <script>
 import PredictionChoiceTeam from './PredictionChoiceTeam'
 import PredictionChoiceDraw from './PredictionChoiceDraw'
-import { formatDateTime } from '@/utils/helpers'
+import { formatTime } from '@/utils/helpers'
 
 export default {
   components: { PredictionChoiceTeam, PredictionChoiceDraw },
@@ -79,7 +79,7 @@ export default {
         return 'default'
       }
     },
-    formatDateTime,
+    formatTime,
   },
 
   computed: {
@@ -92,7 +92,7 @@ export default {
       } else if (this.match.status === 'started') {
         return 'In Progress'
       } else {
-        return this.formatDateTime(this.match.kickoffTime)
+        return 'Kick-off at ' + this.formatTime(this.match.kickoffTime)
       }
     },
     madePrediction() {

--- a/src/components/MatchesGrouping.vue
+++ b/src/components/MatchesGrouping.vue
@@ -1,27 +1,42 @@
 <template>
-  <div v-if="matches.length" class="mb-10">
-    <h3 class="text-center uppercase">{{ title }}</h3>
-    <MatchCard
-      v-for="match in matches"
-      :key="match.id"
-      :match="match"
-      :selectable="match.status == 'upcoming'"
-    />
+  <div v-if="Object.keys(matches).length || $slots.default" class="mb-10">
+    <h3 class="text-center uppercase font-normal">{{ title }}</h3>
+    <slot />
+    <div v-for="(dayMatches, date) in matches" :key="date">
+      <div v-if="dayMatches.length">
+        <h4
+          v-if="date !== formatDate(new Date())"
+          class="text-center font-light m-12"
+          >{{ date }}
+        </h4>
+        <MatchCard
+          v-for="match in dayMatches"
+          :key="match.id"
+          :match="match"
+          :selectable="match.status == 'upcoming'"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
 import MatchCard from '@/components/MatchCard'
+import { formatDate } from '@/utils/helpers'
 
 export default {
   components: { MatchCard },
 
   props: {
     matches: {
-      type: Array,
-      default: () => [],
+      type: Object,
+      default: () => {},
     },
     title: String,
+  },
+
+  methods: {
+    formatDate,
   },
 }
 </script>

--- a/src/components/MatchesGrouping.vue
+++ b/src/components/MatchesGrouping.vue
@@ -1,7 +1,6 @@
 <template>
-  <div v-if="Object.keys(matches).length || $slots.default" class="mb-10">
+  <div v-if="Object.keys(matches).length" class="mb-10">
     <h3 class="text-center uppercase font-normal">{{ title }}</h3>
-    <slot />
     <div v-for="(dayMatches, date) in matches" :key="date">
       <div v-if="dayMatches.length">
         <h4

--- a/src/components/_BaseLink.vue
+++ b/src/components/_BaseLink.vue
@@ -1,8 +1,8 @@
 <template>
-  <a v-if="href" :href="href" target="_blank" v-bind="$attrs">
+  <a v-if="href" :href="href" target="_blank" v-bind="$attrs" :style="style">
     <slot />
   </a>
-  <RouterLink v-else :to="routerLinkTo" v-bind="$attrs">
+  <RouterLink v-else :to="routerLinkTo" v-bind="$attrs" :style="style">
     <slot />
   </RouterLink>
 </template>
@@ -31,6 +31,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     routerLinkTo({ name, params }) {
@@ -38,6 +42,12 @@ export default {
         name,
         params,
         ...(this.to || {}),
+      }
+    },
+    style() {
+      return {
+        cursor: this.disabled ? 'default' : 'pointer',
+        'pointer-events': this.disabled ? 'none' : 'auto',
       }
     },
   },

--- a/src/store/modules/users.js
+++ b/src/store/modules/users.js
@@ -14,9 +14,11 @@ export const mutations = {
 }
 
 export const actions = {
-  fetchUser({ commit, state, rootState }, { userId }) {
+  fetchUser({ commit, state, rootState }, { userId, competitionId }) {
     // 1. Check if we already have the user as a current user.
     const { currentUser } = rootState.auth
+    const { currentCompetitionId } = rootState.competitions
+    competitionId = competitionId || currentCompetitionId
     if (currentUser && currentUser.id === userId) {
       return Promise.resolve(currentUser)
     }
@@ -29,7 +31,7 @@ export const actions = {
 
     // 3. Fetch the user from the API and cache it in case
     //    we need it again in the future.
-    return UsersRepository.getUser(userId).then(response => {
+    return UsersRepository.getUser(userId, { competitionId }).then(response => {
       const user = response.data
       commit('CACHE_USER', user)
       return user

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -15,12 +15,28 @@ export function clearLocalStorage() {
   window.localStorage.clear()
 }
 
-export function formatDateTime(date) {
-  return new Date(date).toLocaleTimeString('en-GB', {
+export function formatDate(date) {
+  return new Date(date).toLocaleDateString(navigator.language || 'en-GB', {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+  })
+}
+
+export function formatDateTime(date) {
+  return new Date(date).toLocaleTimeString(navigator.language || 'en-GB', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function formatTime(date) {
+  return new Date(date).toLocaleTimeString(navigator.language || 'en-GB', {
     hour: '2-digit',
     minute: '2-digit',
   })

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="pb-20">
-    <MatchesGrouping v-if="!viewingOwnMatches" title="Predictions made by">
-      <LeaderboardRanking :user="user" />
-    </MatchesGrouping>
+    <div v-if="!viewingOwnMatches" class="mb-12">
+      <p class="text-center text-xl font-normal m-3">Predictions made by</p>
+      <LeaderboardRanking :user="user" class="m-auto max-w-xs" />
+    </div>
     <div v-else class="flex justify-center items-center my-8">
       <BaseButton
         v-if="missingPredictions.length"
@@ -48,9 +49,7 @@ export default {
   },
 
   async mounted() {
-    if (this.viewingOwnMatches) {
-      if (this.matches.length) this.$emit('init')
-    } else {
+    if (!this.viewingOwnMatches) {
       this.user = await this.fetchUser({ userId: this.userId })
     }
     await this.fetchMatches({ userId: this.userId })
@@ -66,6 +65,12 @@ export default {
         points: null,
       },
     }
+  },
+
+  watch: {
+    matches(newValue) {
+      if (newValue.length) this.$emit('init')
+    },
   },
 
   computed: {

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="pb-20">
-    <div class="flex justify-center">
+    <MatchesGrouping v-if="!viewingOwnMatches" title="Predictions made by">
+      <LeaderboardRanking :user="user" />
+    </MatchesGrouping>
+    <div v-else class="flex justify-center items-center my-8">
       <BaseButton
         v-if="missingPredictions.length"
         class="uppercase text-center m-5"
@@ -26,10 +29,16 @@
 
 <script>
 import MatchesGrouping from '@/components/MatchesGrouping'
+import LeaderboardRanking from '@/components/LeaderboardRanking'
 import { mapGetters, mapActions } from 'vuex'
+import { authComputed } from '@/store/helpers'
+import { formatDate } from '@/utils/helpers'
+import groupBy from 'lodash/groupBy'
 
 export default {
-  components: { MatchesGrouping },
+  name: 'Matches',
+
+  components: { MatchesGrouping, LeaderboardRanking },
 
   props: {
     userId: {
@@ -39,8 +48,11 @@ export default {
   },
 
   async mounted() {
-    if (this.matches.length) this.$emit('init')
-
+    if (this.viewingOwnMatches) {
+      if (this.matches.length) this.$emit('init')
+    } else {
+      this.user = await this.fetchUser({ userId: this.userId })
+    }
     await this.fetchMatches({ userId: this.userId })
     this.$emit('init')
   },
@@ -48,11 +60,20 @@ export default {
   data() {
     return {
       loading: false,
+      user: {
+        userId: null,
+        name: null,
+        points: null,
+      },
     }
   },
 
   computed: {
+    ...authComputed,
     ...mapGetters({ matches: 'matches/matches' }),
+    viewingOwnMatches() {
+      return this.currentUser.userId === this.userId
+    },
     missingPredictions() {
       return this.matches.filter(
         m => !('prediction' in m) && m.status === 'upcoming'
@@ -62,17 +83,30 @@ export default {
       return [
         {
           title: 'Ongoing Matches',
-          matches: this.matches.filter(m => m.status === 'ongoing'),
+          matches: groupBy(
+            this.matches.filter(m => m.status === 'ongoing'),
+            m => formatDate(new Date(m.kickoffTime))
+          ),
         },
         {
           title: 'Upcoming Matches',
-          matches: this.matches.filter(
-            m => m.status === 'upcoming' && 'prediction' in m
+          matches: groupBy(
+            this.matches.filter(
+              m => m.status === 'upcoming' && 'prediction' in m
+            ),
+            m => formatDate(new Date(m.kickoffTime))
           ),
         },
         {
           title: 'Past Matches',
-          matches: this.matches.filter(m => m.status === 'finished'),
+          matches: groupBy(
+            this.matches
+              .filter(m => m.status === 'finished')
+              .sort(
+                (m1, m2) => new Date(m2.kickoffTime) - new Date(m1.kickoffTime)
+              ),
+            m => formatDate(new Date(m.kickoffTime))
+          ),
         },
       ]
     },
@@ -81,6 +115,7 @@ export default {
   methods: {
     ...mapActions({
       fetchMatches: 'matches/fetchMatches',
+      fetchUser: 'users/fetchUser',
     }),
   },
 }


### PR DESCRIPTION
You need [this PR](https://github.com/dmbf29/predictor-api/pull/65) for this one to work.

- [x] Users are able to load the predictions/matches from other users
- [x] The past matches are sorted by most recent to oldest
- [x] Matches are now grouped by date