### PR TITLE
took full height off so we can see the leaaderboard options

### DIFF
--- a/src/components/LeaderboardActions.vue
+++ b/src/components/LeaderboardActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex justify-between p-2">
+  <div class="flex justify-between p-2 mb-5">
     <LeaderboardAction
       v-for="(button, index) in buttons"
       :key="index"

--- a/src/views/layouts/DefaultLayout.vue
+++ b/src/views/layouts/DefaultLayout.vue
@@ -11,7 +11,6 @@
       <transition>
         <RouterView
           v-show="$store.getters.DOMLoaded && componentInitialized"
-          class="h-full"
           :key="$route.fullPath"
           @init="componentInitialized = true"
         ></RouterView>


### PR DESCRIPTION
Closes #117 

@trouni do you remember what `h-full` was doing? It was preventing us to see the leaderboard actions when it is full of people.

```
<RouterView
          v-show="$store.getters.DOMLoaded && componentInitialized"
          class="h-full"
          :key="$route.fullPath"
          @init="componentInitialized = true"
        ></RouterView>
```