### PR TITLE
removed 'vs.' and centered the DRAW action

### DIFF
--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -5,7 +5,7 @@
       borderStyle,
     ]"
   >
-    <div class="flex align justify-evenly">
+    <div class="flex align justify-evenly items-center">
       <PredictionChoiceTeam
         class="w-1/3"
         :team="match.teamHome"
@@ -16,7 +16,7 @@
       <div
         class="flex flex-col my-2 items-center justify-start px-3 h-full w-1/3"
       >
-        <p class="mb-1 h-8 leading-none flex items-center text-sm">vs</p>
+        <p class="mb-1 h-8 leading-none flex items-center text-sm"></p>
         <div class="flex-grow">
           <PredictionChoiceDraw
             :status="status('draw')"


### PR DESCRIPTION
I'll leave it to you on which one you prefer. 

Original:
<img width="354" alt="Screen Shot 2021-06-15 at 19 44 10" src="https://user-images.githubusercontent.com/25542223/122040131-6be78400-ce12-11eb-9af5-1aef3d3ee6d8.png">

New Centered Version:
<img width="344" alt="Screen Shot 2021-06-15 at 19 44 58" src="https://user-images.githubusercontent.com/25542223/122040168-77d34600-ce12-11eb-992c-8a61dd246bfc.png">
