### PR TITLE
Added a div to center the content on desktop

### DIFF
--- a/src/views/layouts/DefaultLayout.vue
+++ b/src/views/layouts/DefaultLayout.vue
@@ -4,25 +4,27 @@
     <Header :title="title" :img="img">
       <component v-if="subHeader" :is="subHeader" ref="subHeader" />
     </Header>
-    <main
-      class="bg-wrapper overflow-y-auto rounded-t-3xl flex-grow p-4 pb-12 relative"
-      ref="main"
-    >
-      <transition>
-        <RouterView
-          v-show="$store.getters.DOMLoaded && componentInitialized"
-          class="h-full"
-          :key="$route.fullPath"
-          @init="componentInitialized = true"
-        ></RouterView>
-      </transition>
-      <div
-        v-if="!$store.getters.DOMLoaded || !componentInitialized"
-        class="flex justify-center items-center h-full w-full"
+    <div class="flex justify-center w-full h-full">
+      <main
+        class="bg-wrapper overflow-y-auto rounded-t-3xl flex-grow p-4 pb-12 relative max-w-screen-md"
+        ref="main"
       >
-        <BaseSpinner class="text-gray-600" />
-      </div>
-    </main>
+        <transition>
+          <RouterView
+            v-show="$store.getters.DOMLoaded && componentInitialized"
+            class="h-full"
+            :key="$route.fullPath"
+            @init="componentInitialized = true"
+          ></RouterView>
+        </transition>
+        <div
+          v-if="!$store.getters.DOMLoaded || !componentInitialized"
+          class="flex justify-center items-center h-full w-full"
+        >
+          <BaseSpinner class="text-gray-600" />
+        </div>
+      </main>
+    </div>
     <FooterNav />
   </div>
 </template>

--- a/src/views/layouts/DefaultLayout.vue
+++ b/src/views/layouts/DefaultLayout.vue
@@ -4,7 +4,7 @@
     <Header :title="title" :img="img">
       <component v-if="subHeader" :is="subHeader" ref="subHeader" />
     </Header>
-    <div class="flex justify-center w-full h-full">
+    <div class="flex justify-center w-full h-full overflow-scroll">
       <main
         class="bg-wrapper overflow-y-auto rounded-t-3xl flex-grow p-4 pb-12 relative max-w-screen-md"
         ref="main"


### PR DESCRIPTION
Our desktop container got lost along the way somewhere. I was pretty nervous implementing this since i thought i might break some swiper things, but appears to be okay...

I just added a `div` around the `main`
```
<div class="flex justify-center w-full h-full">
```
then added a max-width on the `main`
```
max-w-screen-md
```

#### Screens:
<img width="1277" alt="Screen Shot 2021-06-16 at 13 08 40" src="https://user-images.githubusercontent.com/25542223/122156643-5ae75300-cea4-11eb-9cfa-0fa07c6db5c3.png">
<img width="1279" alt="Screen Shot 2021-06-16 at 13 08 48" src="https://user-images.githubusercontent.com/25542223/122156648-5e7ada00-cea4-11eb-94a1-6f7c01817918.png">
<img width="1276" alt="Screen Shot 2021-06-16 at 13 09 02" src="https://user-images.githubusercontent.com/25542223/122156650-5f137080-cea4-11eb-9a9a-a9be94016999.png">


