### PR TITLE
navbar bg-color && grayed out icon

### DIFF
--- a/src/components/NavBarRoutes.vue
+++ b/src/components/NavBarRoutes.vue
@@ -12,6 +12,10 @@ export default {
       type: Array,
       required: true,
     },
+    top: {
+      type: Boolean,
+      default: false,
+    },
   },
   // Render functions are an alternative to templates
   render(h, { props }) {
@@ -24,6 +28,11 @@ export default {
       )
       return route
     }
+    function customStyle() {
+      return props.top
+        ? 'text-black shadow-inner cursor-default leading-none'
+        : 'text-black shadow-inner bg-gray-100 cursor-default leading-none'
+    }
     // Functional components are the only components allowed
     // to return an array of children, rather than a single
     // root node.
@@ -31,8 +40,8 @@ export default {
       <BaseLink
         key={route.name}
         to={processRoute(route)}
-        exact-active-class='text-black shadow-inner bg-gray-100 cursor-default leading-none'
         class='text-gray-600 flex-grow h-full no-underline'
+        exact-active-class={customStyle()}
       >
         <li class='flex h-full w-full items-center justify-center'>
           <BaseIcon name={route.fontAwesomeClass} />

--- a/src/components/TopNav.vue
+++ b/src/components/TopNav.vue
@@ -7,8 +7,8 @@
         class="logo-img"
     /></BaseLink>
     <ul class="top-nav-container">
-      <NavBarRoutes v-if="loggedIn" :routes="loggedInNavRoutes" />
-      <NavBarRoutes v-else :routes="loggedOutNavRoutes" />
+      <NavBarRoutes v-if="loggedIn" :routes="loggedInNavRoutes" :top="true" />
+      <NavBarRoutes v-else :routes="loggedOutNavRoutes" :top="true" />
     </ul>
   </div>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="home-wrapper">
     <TopNav />
     <main>
       <div class="banner">
@@ -63,6 +63,10 @@ export default {
 
 <style lang="scss" scoped>
 @import '@/styles';
+.home-wrapper {
+  background: linear-gradient(167.4deg, #3e3b7d 0%, #6690b7 88.73%);
+}
+
 .banner {
   background-size: cover;
   background-position: center;


### PR DESCRIPTION
Fixed the white nav bar and stop the icons on top from getting grayed out

<img width="1175" alt="Screen Shot 2021-06-16 at 14 54 28" src="https://user-images.githubusercontent.com/25542223/122167889-8b37ed00-ceb6-11eb-8da4-f1c90afa6f6c.png">

<img width="211" alt="Screen Shot 2021-06-16 at 14 54 36" src="https://user-images.githubusercontent.com/25542223/122167994-ae629c80-ceb6-11eb-8f8e-9dbc7b7edbf2.png">
