### PR TITLE
zoomed into center of flag

### DIFF
--- a/src/components/TeamBadge.vue
+++ b/src/components/TeamBadge.vue
@@ -4,7 +4,7 @@
       'shadow-inner-lg rounded-full h-20 w-20 flex items-center justify-center overflow-hidden bg-contain',
       highlight,
     ]"
-    :style="`background-image: url(${flag});`"
+    :style="`background-image: url(${flag}); background-size: cover; background-position: center;`"
   >
     <p class="text-glow text-4xl select-none">{{ score }}</p>
   </div>


### PR DESCRIPTION
Since the World Cup doesnt have badges (unlike the Euros), the flags we're getting displayed poorly:
<img width="155" alt="Screen Shot 2022-11-12 at 14 54 15" src="https://user-images.githubusercontent.com/25542223/201459623-e830c6d8-ce49-47b2-b368-79ea87862be8.png">

So I put the background position to cover then align in the center:
<img width="157" alt="Screen Shot 2022-11-12 at 14 54 52" src="https://user-images.githubusercontent.com/25542223/201459645-837aaa1a-ef97-4354-a29c-6173c3117b9e.png">
