### PR TITLE
Fix hardcoded competition ID

### DIFF
--- a/src/components/TeamBadge.vue
+++ b/src/components/TeamBadge.vue
@@ -24,7 +24,16 @@ export default {
 
   computed: {
     highlight() {
-      return `border-4 border-prediction-${this.status}`
+      switch (this.status) {
+        case 'correct':
+          return 'border-4 border-prediction-correct'
+        case 'incorrect':
+          return 'border-4 border-prediction-incorrect'
+        case 'selected':
+          return 'border-4 border-prediction-selected'
+        default:
+          return 'border-4 border-prediction-default'
+      }
     },
   },
 }

--- a/src/components/TopNav.vue
+++ b/src/components/TopNav.vue
@@ -29,7 +29,6 @@ export default {
         },
         {
           name: 'leaderboards',
-          params: { id: 1 },
           title: 'Leaderboards',
           fontAwesomeClass: 'trophy',
         },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,10 +20,6 @@ router.beforeEach(async (routeTo, routeFrom, next) => {
     NProgress.start()
   }
 
-  // Fetch competitions if missing
-  if (!store.getters['competitions/currentCompetition'])
-    await store.dispatch('competitions/fetchCompetitions')
-
   // Check if auth is required on this route
   // (including nested routes).
   const authRequired = routeTo.matched.some(route => route.meta.authRequired)

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -37,12 +37,28 @@ export const actions = {
   // init({ state, dispatch }) {},
 
   // Logs in the current user.
-  logIn({ commit }, { email, password } = {}) {
-    return logIn({ email, password }).then(response => {
+  logIn({ commit, rootGetters, dispatch }, { email, password } = {}) {
+    return logIn({ email, password }).then(async (response) => {
       const user = response.data.data
       const headers = response.headers
       commit('SET_CURRENT_USER', user)
       commit('SET_AUTH_HEADERS', headers)
+
+      // Fetch competitions and set current competition if missing
+      if (!rootGetters['competitions/currentCompetitionId']) {
+        const competitions = await dispatch(
+          'competitions/fetchCompetitions',
+          {},
+          { root: true }
+        )
+        if (competitions.length > 0) {
+          const competitionId =
+            process.env.VUE_APP_COMPETITION_ID ||
+            competitions[competitions.length - 1].id
+          dispatch('competitions/selectCompetition', competitionId, { root: true })
+        }
+      }
+
       return user
     })
   },

--- a/src/store/modules/competitions.js
+++ b/src/store/modules/competitions.js
@@ -42,16 +42,9 @@ export const mutations = {
 }
 
 export const actions = {
-  fetchCompetitions({ dispatch, commit, state }) {
+  fetchCompetitions({ commit }) {
     return CompetitionsRepository.getCompetitions().then(response => {
       commit('SET_COMPETITIONS', response.data)
-      if (!state.currentCompetitionId && response.data.length > 0) {
-        // TODO: The comepetition id was default at first [0], now last.
-        dispatch(
-          'selectCompetition',
-          response.data[response.data.length - 1].id
-        )
-      }
       return response.data
     })
   },


### PR DESCRIPTION
- Remove hardcoded competition ID from route
- Fix missing dynamic class due to Tailwind JIT

Also slightly refactored the login logic to fetch the current competition upon login. The competition can also be forced via an ENV `VUE_APP_COMPETITION_ID`.