### PR TITLE
quick fix to move buttons higher

### DIFF
--- a/src/components/PredictionSwiper.vue
+++ b/src/components/PredictionSwiper.vue
@@ -37,7 +37,7 @@
         </transition>
       </div>
       <div
-        class="w-full text-center flex flex-col justify-center items-center h-2/5"
+        class="w-full text-center flex flex-col justify-start items-center h-2/5"
       >
         <div v-if="showConfirm" class="contents">
           <h4 class="text-xl mb-3 text-glow z-50"


### PR DESCRIPTION
This isn't perfect. But looked like a quick way to make it look marginally better. I couldn't actually replicate the problem in the browser properly. 

Before:
<img width="378" alt="Screen Shot 2022-11-20 at 21 41 17" src="https://user-images.githubusercontent.com/25542223/202902475-b05a03d6-faec-4b56-bcc6-e8593804b3e1.png">

After:
<img width="380" alt="Screen Shot 2022-11-20 at 21 41 30" src="https://user-images.githubusercontent.com/25542223/202902478-15606abb-6b51-49a9-8caf-156411e7034e.png">

