### PR TITLE
changed incorrect to wrong

### DIFF
--- a/src/components/TeamBadge.vue
+++ b/src/components/TeamBadge.vue
@@ -27,8 +27,8 @@ export default {
       switch (this.status) {
         case 'correct':
           return 'border-4 border-prediction-correct'
-        case 'incorrect':
-          return 'border-4 border-prediction-incorrect'
+        case 'wrong':
+          return 'border-4 border-prediction-wrong'
         case 'selected':
           return 'border-4 border-prediction-selected'
         default:


### PR DESCRIPTION
Not sure when it switched from `incorrect` to `wrong`

Current:
<img width="919" alt="Screen Shot 2022-11-22 at 11 28 01" src="https://user-images.githubusercontent.com/25542223/203203815-1cbcf085-f103-4e54-9ea2-4f923954b389.png">

Fix:
<img width="917" alt="Screen Shot 2022-11-22 at 11 28 24" src="https://user-images.githubusercontent.com/25542223/203203939-298cbd35-6fd4-40ab-bcc3-0f343e2946ea.png">
