### PR TITLE
Hide prediction card if no prediction was made #200

### DIFF
--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -17,6 +17,8 @@
         v-if="match.groupId"
         class="flex flex-col my-2 items-center justify-start px-3 h-full w-1/3"
       >
+        <p class="text-md text-red-300" v-if="finished && !madePrediction">
+        No prediction made</p>
         <p class="mb-1 h-8 leading-none flex items-center text-sm"></p>
         <div class="flex-grow">
           <PredictionChoiceDraw
@@ -34,7 +36,7 @@
         @click.native="setPrediction('away')"
       />
     </div>
-    <CornerPoints v-if="finished" :correct="correctPrediction" />
+    <CornerPoints v-if="finished && madePrediction" :correct="correctPrediction" />
     <p class="text-xs text-gray-400">{{ matchDate }}</p>
   </div>
 </template>
@@ -122,6 +124,10 @@ export default {
     },
     borderStyle() {
       if (this.match.status === 'finished') {
+        // Game finished - Didn't make a prediction
+        if (!this.madePrediction) {
+          return 'border-prediction-default'
+        }
         // Game finished - Prediction is either right or wrong/missing
         return this.correctPrediction
           ? 'border-prediction-correct border-opacity-20'


### PR DESCRIPTION
- Could make something fancier but kept it simple for now
![Screen Shot 2022-11-23 at 16 25 09](https://user-images.githubusercontent.com/87453991/203491699-0dd28ed1-0c99-47b9-8672-2899c3bbb2ba.png)


- no top right Icon
- border-default (grey)
- no prediction was made text