### PR TITLE
Add snap scroll switching of leaderboards

### DIFF
--- a/src/components/AnimatedArrow.vue
+++ b/src/components/AnimatedArrow.vue
@@ -1,0 +1,138 @@
+<template>
+  <div :class="direction" :style="cssProps">
+    <span class="arrow"></span>
+    <p v-html="text"></p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AnimatedArrow',
+
+  props: {
+    up: {
+      type: Boolean,
+      default: false,
+    },
+    down: {
+      type: Boolean,
+      default: false,
+    },
+    left: {
+      type: Boolean,
+      default: false,
+    },
+    right: {
+      type: Boolean,
+      default: false,
+    },
+    text: {
+      type: String,
+      required: false
+    },
+    color: {
+      type: String,
+      default: 'black'
+    }
+  },
+
+  computed: {
+    direction() {
+      if (this.up) return 'up'
+      else if (this.down) return 'down'
+      else if (this.left) return 'left'
+      else if (this.right) return 'right'
+      else return ''
+    },
+    cssProps() {
+      return {
+        '--color': this.color,
+      }
+    }
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles';
+
+@keyframes uparrow {
+  0% {
+    -webkit-transform: translateY(0);
+    opacity: 0.4;
+  }
+  100% {
+    -webkit-transform: translateY(-0.4em);
+    opacity: 0.9;
+  }
+}
+@keyframes downarrow {
+  0% {
+    -webkit-transform: translateY(0);
+    opacity: 0.4;
+  }
+  100% {
+    -webkit-transform: translateY(0.4em);
+    opacity: 0.9;
+  }
+}
+@keyframes leftarrow {
+  0% {
+    -webkit-transform: translateX(0);
+    opacity: 0.4;
+  }
+  100% {
+    -webkit-transform: translateX(-0.4em);
+    opacity: 0.9;
+  }
+}
+@keyframes rightarrow {
+  0% {
+    -webkit-transform: translateX(0);
+    opacity: 0.4;
+  }
+  100% {
+    -webkit-transform: translateX(0.4em);
+    opacity: 0.9;
+  }
+}
+
+.arrow {
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1em;
+  display: block;
+  height: 0;
+  opacity: 0.4;
+  text-indent: -9999px;
+  transform-origin: 50% 50%;
+  width: 0;
+}
+
+.up,
+.down,
+.left,
+.right {
+  color: var(--color);
+  @apply flex items-center gap-3;
+}
+.up {
+  animation: uparrow 0.6s infinite alternate ease-in-out;
+  & .arrow { border-bottom: 1em solid var(--color); }
+  @apply flex-col text-center;
+}
+.down {
+  animation: downarrow 0.6s infinite alternate ease-in-out;
+  & .arrow { border-top: 1em solid var(--color); }
+  @apply flex-col flex-col-reverse text-center;
+}
+.left {
+  animation: leftarrow 0.6s infinite alternate ease-in-out;
+  & .arrow { border-right: 1em solid var(--color); }
+}
+.right {
+  & .arrow { border-left: 1em solid var(--color); }
+  animation: rightarrow 0.6s infinite alternate ease-in-out;
+  @apply flex-row-reverse text-right;
+}
+</style>

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -9,14 +9,16 @@
       :points="points"
       class="mt-1"
     />
+    <LeaderboardActions :leaderboard="leaderboard" />
   </div>
 </template>
 
 <script>
 import LeaderboardRanking from '@/components/LeaderboardRanking'
+import LeaderboardActions from '@/components/LeaderboardActions'
 
 export default {
-  components: { LeaderboardRanking },
+  components: { LeaderboardRanking, LeaderboardActions },
 
   props: {
     leaderboard: {

--- a/src/components/LeaderboardSubHeader.vue
+++ b/src/components/LeaderboardSubHeader.vue
@@ -26,12 +26,6 @@ export default {
     ...mapActions({
       selectLeaderboard: 'leaderboards/selectLeaderboard',
     }),
-    onSwipeLeft() {
-      this.selectLeaderboard(this.nextLeaderboard?.id)
-    },
-    onSwipeRight() {
-      this.selectLeaderboard(this.previousLeaderboard?.id)
-    },
   },
 
   computed: {

--- a/src/store/modules/leaderboards.js
+++ b/src/store/modules/leaderboards.js
@@ -5,7 +5,6 @@ const LeaderboardsRepository = RepositoryFactory.get('leaderboards')
 
 // Not really sure about this
 export const state = {
-  cached: [],
   leaderboards: getSavedState('leaderboards'),
   currentLeaderboardId: getSavedState('currentLeaderboardId'),
 }

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { config } from '@/constants'
 import store from '@/store'
+import NProgress from 'nprogress/nprogress'
 
 // create an axios instance
 const service = axios.create({
@@ -11,11 +12,13 @@ const service = axios.create({
 // request interceptor
 service.interceptors.request.use(
   serviceConfig => {
+    NProgress.start()
     const authHeaders = store.getters['auth/headers']
     serviceConfig.headers = { ...serviceConfig.headers, ...authHeaders }
     return serviceConfig
   },
   error => {
+    NProgress.done()
     Promise.reject(error)
   }
 )
@@ -23,6 +26,7 @@ service.interceptors.request.use(
 // response interceptor
 service.interceptors.response.use(
   response => {
+    NProgress.done()
     if (response.status < 200 || response.status >= 300) console.warn(response)
 
     // Seems like cached requests don't generate new tokens.
@@ -32,6 +36,7 @@ service.interceptors.response.use(
     return response
   },
   error => {
+    NProgress.done()
     console.warn(error)
     if (
       store.getters['auth/loggedIn'] &&

--- a/src/views/ForgotPassword.vue
+++ b/src/views/ForgotPassword.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col justify-center items-center">
+  <div class="p-4 flex flex-col justify-center items-center">
     <div class="w-full md:w-6/12">
       <div v-if="success">
         <p>We've sent you an email with a link to reset your password.</p>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-4 home-wrapper">
+  <div class="home-wrapper">
     <TopNav />
     <main>
       <div class="banner">

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="home-wrapper">
+  <div class="p-4 home-wrapper">
     <TopNav />
     <main>
       <div class="banner">

--- a/src/views/LeaderboardNew.vue
+++ b/src/views/LeaderboardNew.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="p-4">
     <p>Name</p>
     <BaseInputText
       v-model="name"

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col justify-center items-center">
+  <div class="p-4 flex flex-col justify-center items-center">
     <div class="w-full md:w-6/12">
       <p v-if="register">
         Already got an account?

--- a/src/views/Predict.vue
+++ b/src/views/Predict.vue
@@ -1,5 +1,5 @@
 <template>
-  <PredictionSwiper :matches="missingPredictions" @remove="removeMatch" />
+  <PredictionSwiper :matches="missingPredictions" @remove="removeMatch" class="p-4" />
 </template>
 
 <script>

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="pb-20">
-    <div v-if="!viewingOwnMatches" class="mb-12">
+  <div class="p-4 pb-20">
       <p class="text-center text-xl font-normal m-3">Predictions made by</p>
       <LeaderboardRanking :users="[user]" class="m-auto max-w-xs" />
     </div>

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="p-4 pb-20">
+    <div v-if="userId" class="mb-12">
+      <p @click="() => $router.go(-1)">
+        <BaseIcon name="chevron-left" /> Back to Rankings
+      </p>
       <p class="text-center text-xl font-normal m-3">Predictions made by</p>
       <LeaderboardRanking :users="[user]" class="m-auto max-w-xs" />
     </div>
@@ -70,7 +74,7 @@ export default {
   },
 
   async mounted() {
-    if (!this.viewingOwnMatches) {
+    if (this.userId) {
       this.user = await this.fetchUser({ userId: this.userId })
       // Removing 'UPCOMING' for other users' pages
       const upcomingIndex = this.tabs.indexOf('upcoming')
@@ -109,9 +113,6 @@ export default {
   computed: {
     ...authComputed,
     ...mapGetters({ matches: 'matches/matches' }),
-    viewingOwnMatches() {
-      return this.currentUser.userId === this.userId
-    },
     missingPredictions() {
       return this.matches.filter(
         m => !('prediction' in m) && m.status === 'upcoming'

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -1,6 +1,11 @@
 <template>
-  <SnapNavigationLayout :items="leaderboards" ref="snapNav" @change-item="changeLeaderboard">
-    <template v-slot:item="{ item: leaderboard }"> 
+  <SnapNavigationLayout
+    :items="leaderboards"
+    ref="snapNav"
+    @change-item="changeLeaderboard"
+    watched-tutorial-state-key="watchedRankingsTutorial"
+  >
+    <template v-slot:item="{ item: leaderboard }">
       <LeaderboardRankingsCard
         :leaderboard="leaderboard"
         :key="leaderboard.id"

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -13,8 +13,6 @@
 import LeaderboardRankingsCard from '@/components/LeaderboardRankingsCard'
 import SnapNavigationLayout from '@/views/layouts/SnapNavigationLayout.vue'
 import { mapGetters, mapActions } from 'vuex'
-// mapGetters is used to import Getters from your store into your component
-// There are also similar mapState, mapActions, mapMutations methods.
 
 export default {
   components: { LeaderboardRankingsCard, SnapNavigationLayout },
@@ -41,8 +39,6 @@ export default {
   },
 
   watch: {
-    // This is a watcher that will fire when the leaderboard changes. We want to scroll to the
-    // leaderboard that is currently selected.
     currentLeaderboard(leaderboard) {
       const index = this.leaderboards.findIndex(l => l.id === leaderboard.id)
       this.$refs.snapNav.goToPage(index)

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col justify-center items-center">
+  <div class="flex flex-col justify-center items-center p-4">
     <div class="w-full md:w-6/12">
       <div>
         <p>New password</p>

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -1,5 +1,10 @@
 <template>
-  <SnapNavigationLayout :items="leaderboards" ref="snapNav" @change-item="changeLeaderboard">
+  <SnapNavigationLayout
+    :items="leaderboards"
+    ref="snapNav"
+    @change-item="changeLeaderboard"
+    watched-tutorial-state-key="watchedResultsTutorial"
+  >
     <template v-slot:item="{ item: leaderboard }"> 
       <LeaderboardResults :leaderboard="leaderboard" :key="leaderboard.id" />
     </template>
@@ -48,6 +53,7 @@ export default {
 
   methods: {
     ...mapActions({
+      selectLeaderboard: 'leaderboards/selectLeaderboard',
       fetchLeaderboards: 'leaderboards/fetchLeaderboards',
       joinLeaderboard: 'leaderboards/joinLeaderboard',
     }),

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -1,26 +1,20 @@
 <template>
-  <div>
-    <LeaderboardResults
-      :key="leaderboard.id"
-      :leaderboard="leaderboard"
-      v-if="leaderboard"
-    />
-    <p v-else class="placeholder-text">
-      Join or create a leaderboard to get started!
-    </p>
-    <LeaderboardActions :leaderboard="leaderboard" />
-  </div>
+  <SnapNavigationLayout :items="leaderboards" ref="snapNav" @change-item="changeLeaderboard">
+    <template v-slot:item="{ item: leaderboard }"> 
+      <LeaderboardResults :leaderboard="leaderboard" :key="leaderboard.id" />
+    </template>
+  </SnapNavigationLayout>
 </template>
 
 <script>
 import LeaderboardResults from '@/components/LeaderboardResults'
-import LeaderboardActions from '@/components/LeaderboardActions'
+import SnapNavigationLayout from '@/views/layouts/SnapNavigationLayout.vue'
 import { mapGetters, mapActions } from 'vuex'
 // mapGetters is used to import Getters from your store into your component
 // There are also similar mapState, mapActions, mapMutations methods.
 
 export default {
-  components: { LeaderboardResults, LeaderboardActions },
+  components: { LeaderboardResults, SnapNavigationLayout },
 
   props: {
     userId: {
@@ -30,23 +24,26 @@ export default {
   },
 
   async mounted() {
-    if (this.leaderboard) this.$emit('init')
+    if (this.currentLeaderboard) this.$emit('init')
 
     await this.fetchLeaderboards()
     this.$emit('init')
   },
 
-  // The state is managed from the store, we don't want to be reassigning these variables
-  // directly in here (defeats the purpose of the store). Instead of declaring them in data (state)
-  // for the component, we use computed properties.
-
   computed: {
     ...mapGetters({
-      // This syncs the store getters to the component as computed properties. You never have to reassign
-      // them within this component, any changes to them should happen at the store level.
-      // We only need the current leaderboard in this component.
-      leaderboard: 'leaderboards/currentLeaderboard',
+      currentLeaderboard: 'leaderboards/currentLeaderboard',
+      leaderboards: 'leaderboards/leaderboards',
     }),
+  },
+
+  watch: {
+    // This is a watcher that will fire when the leaderboard changes. We want to scroll to the
+    // leaderboard that is currently selected.
+    currentLeaderboard(leaderboard) {
+      const index = this.leaderboards.findIndex(l => l.id === leaderboard.id)
+      this.$refs.snapNav.goToPage(index)
+    },
   },
 
   methods: {
@@ -54,19 +51,9 @@ export default {
       fetchLeaderboards: 'leaderboards/fetchLeaderboards',
       joinLeaderboard: 'leaderboards/joinLeaderboard',
     }),
-  },
-  data() {
-    return {
-      selectedTab: 'All',
-    }
+    changeLeaderboard(index) {
+      this.selectLeaderboard(this.leaderboards[index].id)
+    },
   },
 }
 </script>
-
-<style lang="scss" scoped>
-@import '@/styles';
-.placeholder-text {
-  color: $purple;
-  text-align: center;
-}
-</style>

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="p-4">
     <div class="flex flex-col justify-center items-center">
       <div class="w-full md:w-6/12">
         <div class="flex justify-center">

--- a/src/views/layouts/DefaultLayout.vue
+++ b/src/views/layouts/DefaultLayout.vue
@@ -6,7 +6,7 @@
     </Header>
     <div class="flex justify-center w-full h-full overflow-scroll">
       <main
-        class="bg-wrapper overflow-y-auto rounded-t-lg flex-grow p-4 pb-20 relative max-w-screen-md"
+        class="bg-wrapper overflow-y-auto rounded-t-lg flex-grow pb-20 relative max-w-screen-md"
         ref="main"
       >
         <transition>
@@ -35,7 +35,6 @@ import Header from '@/components/Header'
 import FooterNav from '@/components/FooterNav'
 import LeaderboardSubHeader from '@/components/LeaderboardSubHeader'
 import MatchesSubHeader from '@/components/MatchesSubHeader'
-import Hammer from 'hammerjs'
 
 export default {
   components: {
@@ -44,14 +43,6 @@ export default {
     TopNav,
     LeaderboardSubHeader,
     MatchesSubHeader,
-  },
-
-  mounted() {
-    if (this.$refs.subHeader) {
-      const hammer = new Hammer(this.$refs.main)
-      hammer.on('swipeleft', () => this.$refs.subHeader.onSwipeLeft())
-      hammer.on('swiperight', () => this.$refs.subHeader.onSwipeRight())
-    }
   },
 
   data() {

--- a/src/views/layouts/DefaultLayout.vue
+++ b/src/views/layouts/DefaultLayout.vue
@@ -6,7 +6,7 @@
     </Header>
     <div class="flex justify-center w-full h-full overflow-scroll">
       <main
-        class="bg-wrapper overflow-y-auto rounded-t-lg flex-grow pb-20 relative max-w-screen-md"
+        class="bg-wrapper overflow-y-auto rounded-t-lg flex-grow pb-20 md:pb-0 relative max-w-screen-md"
         ref="main"
       >
         <transition>

--- a/src/views/layouts/SnapNavigationLayout.vue
+++ b/src/views/layouts/SnapNavigationLayout.vue
@@ -1,0 +1,61 @@
+<template>
+  <div ref="snapContainer" class="flex w-screen snap-container">
+    <div
+      v-for="(item, index) in items"
+      class="min-w-[100vw] w-screen p-4 snap-section"
+      :key="index"
+      ref="items"
+      :data-item-idx="index"
+    >
+      <slot name="item" :item="item">
+        {{ item.id }}
+      </slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    items: {
+      type: Array,
+      required: true,
+    },
+  },
+
+  mounted() {
+    // var observer = new IntersectionObserver(
+    //   entries => {
+    //     if (entries[0].isIntersecting === true) {
+    //       this.$emit('change-item', entries[0].target.dataset.itemIdx)
+    //     }
+    //   },
+    //   {
+    //     root: this.$refs.snapContainer,
+    //     threshold: [0.9],
+    //   }
+    // )
+
+    // this.$refs.items.forEach(i => observer.observe(i))
+  },
+
+  methods: {
+    goToPage(pageIdx) {
+      this.$refs.items[pageIdx].scrollIntoView()
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.snap-container {
+  overflow: scroll;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+}
+
+.snap-section {
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+}
+</style>

--- a/src/views/layouts/SnapNavigationLayout.vue
+++ b/src/views/layouts/SnapNavigationLayout.vue
@@ -1,15 +1,19 @@
 <template>
-  <div ref="snapContainer" class="flex w-screen snap-container">
+  <div ref="snapContainer" class="flex snap-container h-full">
     <div
       v-for="(item, index) in items"
-      class="min-w-[100vw] w-screen p-4 snap-section"
+      class="snap-section min-w-[100%]"
       :key="index"
       ref="items"
       :data-item-idx="index"
     >
-      <slot name="item" :item="item">
-        {{ item.id }}
-      </slot>
+    <div class="h-full overflow-hidden">
+      <div class="hide-scrollbar h-full overflow-y-scroll p-4">
+        <slot name="item" :item="item">
+          {{ item.id }}
+        </slot>
+      </div>
+    </div>
     </div>
   </div>
 </template>
@@ -24,19 +28,19 @@ export default {
   },
 
   mounted() {
-    // var observer = new IntersectionObserver(
-    //   entries => {
-    //     if (entries[0].isIntersecting === true) {
-    //       this.$emit('change-item', entries[0].target.dataset.itemIdx)
-    //     }
-    //   },
-    //   {
-    //     root: this.$refs.snapContainer,
-    //     threshold: [0.9],
-    //   }
-    // )
+    var observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting === true) {
+          this.$emit('change-item', entries[0].target.dataset.itemIdx)
+        }
+      },
+      {
+        root: this.$refs.snapContainer,
+        threshold: [1],
+      }
+    )
 
-    // this.$refs.items.forEach(i => observer.observe(i))
+    this.$refs.items.forEach(i => observer.observe(i))
   },
 
   methods: {
@@ -57,5 +61,13 @@ export default {
 .snap-section {
   scroll-snap-align: start;
   scroll-snap-stop: always;
+}
+
+.hide-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+  &::-webkit-scrollbar { /* Chrome, Safari and Opera */
+    display: none;
+  }
 }
 </style>


### PR DESCRIPTION
This PR mainly implements a snap scroll behaviour to switch between leaderboards.

Other improvements added by this PR:
- Add tutorial for leaderboard swipe (state is saved in local storage so that it only shows up once)
- Add back button for user predictions
- Add progress bar whenever an API request is in progress to see if data is refreshing in the background

### Snap scroll navigation

https://user-images.githubusercontent.com/34345789/204815216-f50e0d0f-46d2-4c98-bd0d-0d46eae90f6d.MP4

### "Back to Rankings" button on user predictions

![image](https://user-images.githubusercontent.com/34345789/204773243-1ccc750d-d1b1-4e16-badc-7d5cb05ba770.png)
