### PR TITLE
Fixing various minor issues

### DIFF
--- a/src/components/FooterNav.vue
+++ b/src/components/FooterNav.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     id="footer-nav"
-    class="h-20 shadow-2xl z-50"
+    class="h-20 shadow-2xl z-[100]"
     :class="{ 'bg-gradient': !transparent }"
   >
     <ul class="footer-container flex h-full items-center">

--- a/src/components/LeaderboardAction.vue
+++ b/src/components/LeaderboardAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col gap-3 text-center m-3 py-1">
     <BaseLink v-if="to" :to="to">
-      <BaseIcon :name="icon" /> <span class="mr-1">{{ text }} </span>
+      <BaseIcon :name="icon" /> <span class="ml-1">{{ text }}</span>
     </BaseLink>
     <ShareButton
       v-else-if="action === 'invite'"
@@ -10,11 +10,11 @@
       :icon="icon"
     />
     <div
-      v-else-if="action === 'leave'"
+      v-else-if="action === 'leave' && !leaderboard.leaveDisabled"
       @click="showModal = true"
       class="cursor-pointer"
     >
-      <BaseIcon :name="icon" /> <span class="mr-1">{{ text }} </span>
+      <BaseIcon :name="icon" /> <span class="ml-1">{{ text }}</span>
     </div>
     <ConfirmDelete
       v-if="showModal"

--- a/src/components/PredictionSwiper.vue
+++ b/src/components/PredictionSwiper.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="w-full h-full flex flex-col">
     <div
-      class="overflow-hidden flex flex-col justify-around items-center flex-grow h-full"
+      class="overflow-hidden flex flex-col justify-center items-center flex-grow h-full"
     >
-      <div class="flex flex-col justify-center items-center w-full h-1/5">
+      <div class="absolute flex flex-col justify-center items-center w-full top-8">
         <div v-if="currentMatch" class="text-center">
           <p class="text-gray-500 font-light text-xs md:text-lg">{{
             formatDateTime(currentMatch.kickoffTime)
@@ -28,7 +28,7 @@
             :match="prediction.match"
             :choice="prediction.choice"
             :class="[
-              'pointer-events-none transform transition',
+              'pointer-events-none transition',
               awaitingConfirmation
                 ? 'opacity-100 scale-100'
                 : 'opacity-70 scale-90',
@@ -37,7 +37,7 @@
         </transition>
       </div>
       <div
-        class="w-full text-center flex flex-col justify-start items-center h-2/5"
+        class="w-full text-center flex flex-col justify-start items-center"
       >
         <div v-if="showConfirm" class="contents">
           <h4 class="text-xl mb-3 text-glow z-50"
@@ -52,7 +52,7 @@
       </div>
     </div>
     <div
-      class="h-full overflow-hidden flex flex-col justify-center items-center absolute transform top-1/2 -translate-y-1/2 w-full left-0"
+      class="h-full overflow-hidden flex flex-col justify-center items-center absolute top-1/2 -translate-y-1/2 w-full left-0"
     >
       <PredictionSwiperCard
         v-for="(match, index) in matches"

--- a/src/components/SwipeTutorial.vue
+++ b/src/components/SwipeTutorial.vue
@@ -3,6 +3,7 @@
     <div
       v-if="showTutorial && isTouchDevice"
       @click="hideTutorial"
+      @touchstart="hideTutorial"
       class="fixed md:absolute w-full h-full bg-black/70 z-[60] top-0 left-0 pb-20 backdrop-blur-[2px]"
     >
       <AnimatedArrow
@@ -66,7 +67,7 @@ export default {
   mounted() {
     setTimeout(() => {
       this.showTutorial = !getSavedState(`watched${capitalize(this.$route.name)}Tutorial`)
-    }, 2000)
+    }, 500)
   },
 
   methods: {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,6 +30,11 @@ router.beforeEach(async (routeTo, routeFrom, next) => {
   // If auth is required
   store.getters['auth/loggedIn'] ? next() : redirectToLogin()
 
+  // Fetch competitions and set current competition if missing
+  if (!store.getters['competitions/currentCompetitionId']) {
+    await store.dispatch('competitions/setDefaultCompetition')
+  }
+
   function redirectToLogin() {
     // Pass the original route to the login component
     next({ name: 'login', query: { redirectFrom: routeTo.fullPath } })

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -43,17 +43,12 @@ export const actions = {
   // init({ state, dispatch }) {},
 
   // Logs in the current user.
-  logIn({ commit, rootGetters, dispatch }, { email, password } = {}) {
+  logIn({ commit }, { email, password } = {}) {
     return logIn({ email, password }).then(async response => {
       const user = response.data.data
       const headers = response.headers
       commit('SET_CURRENT_USER', user)
       commit('SET_AUTH_HEADERS', headers)
-
-      // Fetch competitions and set current competition if missing
-      if (!rootGetters['competitions/currentCompetitionId']) {
-        await dispatch('competitions/setDefaultCompetition', {}, { root: true })
-      }
 
       return user
     })

--- a/src/views/LeaderboardNew.vue
+++ b/src/views/LeaderboardNew.vue
@@ -28,7 +28,7 @@ export default {
       leaderboardId: null,
     }
   },
-  async mounted() {
+  mounted() {
     this.$emit('init')
   },
   methods: {

--- a/src/views/Predict.vue
+++ b/src/views/Predict.vue
@@ -9,8 +9,8 @@ import { mapGetters, mapActions } from 'vuex'
 export default {
   components: { PredictionSwiper },
 
-  async mounted() {
-    await this.fetchMatches()
+  mounted() {
+    this.fetchMatches()
     this.$emit('init')
   },
 

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -32,6 +32,7 @@ export default {
     if (this.currentLeaderboard) this.$emit('init')
 
     await this.fetchLeaderboards()
+    await this.fetchMatches()
     this.$emit('init')
   },
 
@@ -55,6 +56,7 @@ export default {
     ...mapActions({
       selectLeaderboard: 'leaderboards/selectLeaderboard',
       fetchLeaderboards: 'leaderboards/fetchLeaderboards',
+      fetchMatches: 'matches/fetchMatches',
       joinLeaderboard: 'leaderboards/joinLeaderboard',
     }),
     changeLeaderboard(index) {

--- a/src/views/layouts/SnapNavigationLayout.vue
+++ b/src/views/layouts/SnapNavigationLayout.vue
@@ -62,7 +62,7 @@ export default {
       },
       {
         root: this.$refs.snapContainer,
-        threshold: [1],
+        threshold: [0.95],
       }
     )
 


### PR DESCRIPTION
Some minor fixes that I've noticed while testing around:
- [Change `IntersectionObserver` threshold to make it feel more reactive](https://github.com/trouni/predictor-vue/pull/234/commits/224943433b003b993ab2574af9bd64782df692c7)
- [Fetch matches upon mounting the Results component](https://github.com/trouni/predictor-vue/pull/234/commits/6c991aee4aa583339c44140353ecdbd726724382) (the matches may be missing if the user does not visit the Predict page)
- [Reduce delay for tutorial start and hide on `touchstart` event](https://github.com/trouni/predictor-vue/pull/234/commits/ae2c7c7105be1c2bb5017795be76a1252f37f2bb) (not just click)
- [Increase footer's `z-index` to be on top of tutorial overlay](https://github.com/trouni/predictor-vue/pull/234/commits/0ae0014ecd35d7e093bdda92235a1b9365792e46)
- [Hide "Leave leaderboard" button if `leaveDisabled` flag is `true`](https://github.com/trouni/predictor-vue/pull/234/commits/852a6d3af8c996444bba9ca37a5fca6ed2d6374f) (will be needed for dmbf29/predictor-api#111, added it now since it is a non-breaking addition)
- [Prevent team names from jumping up and down when swiping](https://github.com/trouni/predictor-vue/pull/234/commits/05a6f15d162f9a61931be54ec310fd5c904f5802)
- [Fix an issue where the `currentCompetitionId` would sometimes be `undefined`, preventing the main view component to intialize](https://github.com/trouni/predictor-vue/pull/234/commits/5a814dc84747af560b56f466a8538ee743df057d)
