### PR TITLE
fix alignment of Prediction Team Choice in Result Card

### DIFF
--- a/src/components/ResultCard.vue
+++ b/src/components/ResultCard.vue
@@ -6,7 +6,7 @@
     ]"
   >
     <p class="border-b pt-2 mt-2 pb-4 mb-4 text-gray-500">{{ matchDate }}</p>
-    <div class="flex align justify-evenly items-center">
+    <div class="flex align justify-around items-center">
       <PredictionChoiceTeam
         class="w-1/3"
         :team="match.teamHome"


### PR DESCRIPTION
One tiny tweak that solves the alignment issue between `PredictionChoiceTeam` component and `MatchPrediction` Pills. 

Before: 


<img width="361" alt="2022-12-10_10-13-15" src="https://user-images.githubusercontent.com/21108437/206821446-cdf72334-b203-43ad-b5ae-001464ef74d2.png">


After:

<img width="364" alt="2022-12-10_10-13-29" src="https://user-images.githubusercontent.com/21108437/206821454-487697cb-90bc-49f4-82af-a0a8e03c1f42.png">


