### PR TITLE
Added a placeholder card for users when they haven't made any predictions

### DIFF
--- a/src/components/LeaderboardRanking.vue
+++ b/src/components/LeaderboardRanking.vue
@@ -12,12 +12,12 @@
         <p>-</p>
       </div> -->
       <div class="flex flex-col gap-2">
-        <div v-for="user in users" :key="user.id" class="d-flex">
+        <div v-for="ranking in userRankings" :key="ranking.userId" class="d-flex">
           <div class="user-avatar text-center flex-shrink-0">
             <div class="relative rounded-full overflow-hidden">
-              <cld-context v-if="user.photoKey || user.photo_key" :cloudName="cloudName">
+              <cld-context v-if="ranking.photoKey || ranking.photo_key" :cloudName="cloudName">
                 <div class="">
-                  <cld-image :publicId="user.photoKey || user.photo_key">
+                  <cld-image :publicId="ranking.photoKey || ranking.photo_key">
                     <cld-transformation
                       width="100"
                       height="100"
@@ -32,19 +32,19 @@
             </div>
           </div>
           <BaseLink
-            :to="{ name: 'predictions', query: { userId: user.userId } }"
+            :to="{ name: 'predictions', query: { userId: ranking.userId } }"
             :disabled="!linkPredictions"
             class="p-2 name w-full truncate"
           >
-            {{ user.name }}
+            {{ ranking.name }}
           </BaseLink>
         </div>
       </div>
     </div>
     <div  class="points w-12 text-center flex-shrink-0 py-1">
-      {{ users[0].points }}
-      <span v-if="users[0].possiblePoints" class="font-light text-xs">
-        / {{ users[0].possiblePoints }}</span
+      {{ userRankings[0].points }}
+      <span v-if="userRankings[0].possiblePoints" class="font-light text-xs">
+        / {{ userRankings[0].possiblePoints }}</span
       >
     </div>
   </div>
@@ -57,7 +57,7 @@ import { mapGetters } from "vuex";
 
 export default {
   props: {
-    users: {
+    userRankings: {
       type: Array,
     },
     position: {

--- a/src/components/LeaderboardRanking.vue
+++ b/src/components/LeaderboardRanking.vue
@@ -3,8 +3,11 @@
     class="d-flex ranking bg-white/50 w-[95%] mx-auto px-1 py-2 bg-white rounded-lg shadow-lg"
   >
     <div class="d-flex min-w-0">
-      <div class="position text-center flex-shrink-0" :class="{ 'w-12': !!position }">
-        <p v-if="!!position && Number.isInteger(position)" v-html="ordinalize(position)"></p>
+      <div
+        class="position text-center flex-shrink-0"
+        :class="{ 'w-12': !!position || paddingStart }"
+      >
+        <p v-if="!!position" v-html="ordinalize(position)"></p>
       </div>
       <!-- <div class="direction w-12 text-center flex-shrink-0">
         <p><BaseIcon name="caret-up" /></p>
@@ -69,6 +72,10 @@ export default {
       default: null,
     },
     linkPredictions: {
+      type: Boolean,
+      default: false,
+    },
+    paddingStart: {
       type: Boolean,
       default: false,
     },

--- a/src/components/LeaderboardRanking.vue
+++ b/src/components/LeaderboardRanking.vue
@@ -4,7 +4,7 @@
   >
     <div class="d-flex min-w-0">
       <div class="position text-center flex-shrink-0" :class="{ 'w-12': !!position }">
-        <p v-if="!!position" v-html="ordinalize(position)"></p>
+        <p v-if="!!position && Number.isInteger(position)" v-html="ordinalize(position)"></p>
       </div>
       <!-- <div class="direction w-12 text-center flex-shrink-0">
         <p><BaseIcon name="caret-up" /></p>
@@ -42,7 +42,7 @@
       </div>
     </div>
     <div  class="points w-12 text-center flex-shrink-0 py-1">
-      {{ users[0].points || firstUser.points }}
+      {{ users[0].points }}
       <span v-if="users[0].possiblePoints" class="font-light text-xs">
         / {{ users[0].possiblePoints }}</span
       >
@@ -87,12 +87,6 @@ export default {
     ...mapGetters({
       leaderboard: "leaderboards/currentLeaderboard",
     }),
-    firstUser() {
-      const user = this.leaderboard.users.find(
-        (user) => user.userId === this.users[0].id
-      );
-      return user;
-    },
   },
   methods: {
     ordinalize(num) {

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -21,7 +21,7 @@
           points: '-',
         },
       ]"
-      :position="'-'"
+      :padding-start="true"
       :link-predictions="false"
       class="mt-1"
     />

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -23,6 +23,7 @@
       ]"
       :position="'-'"
       :link-predictions="false"
+      class="mt-1"
     />
     <LeaderboardActions :leaderboard="leaderboard" />
   </div>

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -60,7 +60,7 @@ export default {
       return this.leaderboard.users.slice().sort((a, b) => b.points - a.points)
     },
     isCurrentUserRanked() {
-      return this.rankedUsers.some(user => user.id === this.currentUser.id)
+      return this.rankedUsers.some(user => user.userId === this.currentUser.id)
     }
   },
 }

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -3,7 +3,7 @@
     <LeaderboardRanking
       v-for="{ position, points } in ranks"
       :key="position"
-      :users="rankedUsers.filter(user => user.rank === position)"
+      :userRankings="rankedUsers.filter(user => user.rank === position)"
       :position="position"
       :link-predictions="true"
       :points="points"
@@ -13,7 +13,7 @@
     <LeaderboardRanking
       v-if="!isCurrentUserRanked"
       :key="-1"
-      :users="[
+      :userRankings="[
         {
           id: currentUser.id,
           name: currentUser.name,

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -9,17 +9,31 @@
       :points="points"
       class="mt-1"
     />
+    <!-- Placeholder for when the currentUser hasn't made any predictions -->
+    <LeaderboardRanking
+      v-if="!isCurrentUserRanked"
+      :key="-1"
+      :users="[
+        {
+          id: currentUser.id,
+          name: currentUser.name,
+          userId: currentUser.id,
+          points: '-',
+        },
+      ]"
+      :position="'-'"
+      :link-predictions="false"
+    />
     <LeaderboardActions :leaderboard="leaderboard" />
   </div>
 </template>
-
 <script>
 import LeaderboardRanking from '@/components/LeaderboardRanking'
 import LeaderboardActions from '@/components/LeaderboardActions'
+import { mapGetters } from 'vuex'
 
 export default {
   components: { LeaderboardRanking, LeaderboardActions },
-
   props: {
     leaderboard: {
       type: Object,
@@ -27,6 +41,7 @@ export default {
     },
   },
   computed: {
+    ...mapGetters({ currentUser: 'auth/currentUser' }),
     rankedUsers() {
       return this.sortedUsers.map(u => {
         u.rank = this.sortedUsers.findIndex(usr => u.points === usr.points) + 1
@@ -44,6 +59,9 @@ export default {
     sortedUsers: function () {
       return this.leaderboard.users.slice().sort((a, b) => b.points - a.points)
     },
+    isCurrentUserRanked() {
+      return this.rankedUsers.some(user => user.id === this.currentUser.id)
+    }
   },
 }
 </script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -129,6 +129,7 @@ export default [
             path: 'rankings',
             name: 'rankings',
             component: () => import('@/views/Rankings'),
+            props: () => ({ userId: store.getters['auth/currentUser'].id }),
             meta: {
               authRequired: true,
               title: 'Rankings',

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -5,7 +5,7 @@
         <BaseIcon name="chevron-left" /> Back to Rankings
       </p>
       <p class="text-center text-xl font-normal m-3">Predictions made by</p>
-      <LeaderboardRanking :users="[user]" class="m-auto max-w-xs" />
+      <LeaderboardRanking :userRankings="[user]" class="m-auto max-w-xs" />
     </div>
     <div v-else class="flex items-center justify-center my-8">
       <div


### PR DESCRIPTION
This is another placeholder along with #248 for the results

Before and after (when no other members)
<p float='left'>
<img width="200" alt="image" src="https://github.com/trouni/predictor-vue/assets/25542223/63d8f6e1-9df4-4fc3-a73d-aa1868a9ae6e">
<img width="200" alt="image" src="https://github.com/trouni/predictor-vue/assets/25542223/5720e828-b9d8-4663-a21b-645b43919fbf">
</p>

Before and after (when members)
<p float='left'>
<img width="200" alt="image" src="https://github.com/trouni/predictor-vue/assets/25542223/a6af38e1-e214-435a-aa20-826af2f353aa">
<img width="200" alt="image" src="https://github.com/trouni/predictor-vue/assets/25542223/08a9ba6a-95db-4443-8144-ae435fd3fcd6">
</p>