### PR TITLE
bottom mobiles navbar no longer showing up in desktop mode

### DIFF
--- a/src/components/FooterNav.vue
+++ b/src/components/FooterNav.vue
@@ -99,4 +99,11 @@ export default {
     display: inline-block;
   }
 }
+
+// TODO: Hide when desktop
+@media (min-width: 640px) {
+  #footer-nav {
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION
I went to the TopNav component and just did the opposite in the FooterNav

Before
<img width="1511" alt="image" src="https://github.com/trouni/predictor-vue/assets/25542223/9305c7a7-8e98-42da-9477-863ef126c5cf">

After
<img width="1512" alt="image" src="https://github.com/trouni/predictor-vue/assets/25542223/f825b5f7-e70f-4e52-ad64-557b807dc515">
