### PR TITLE
Leaderboard current

### DIFF
--- a/src/views/LeaderboardNew.vue
+++ b/src/views/LeaderboardNew.vue
@@ -34,13 +34,16 @@ export default {
   methods: {
     ...mapActions({
       postLeaderboard: 'leaderboards/postLeaderboard',
+      selectLeaderboard: 'leaderboards/selectLeaderboard',
     }),
     async submit() {
       this.processingForm = true
       const formData = {
         name: this.name,
       }
-      await this.postLeaderboard(formData)
+      this.newLeadboard = await this.postLeaderboard(formData)
+      console.log(this.newLeadboard);
+      this.selectLeaderboard(this.newLeadboard.id)
       this.processingForm = false
       this.$router.push(
         this.$route.query.redirectFrom || { name: 'rankings' }

--- a/src/views/LeaderboardNew.vue
+++ b/src/views/LeaderboardNew.vue
@@ -35,6 +35,7 @@ export default {
     ...mapActions({
       postLeaderboard: 'leaderboards/postLeaderboard',
       selectLeaderboard: 'leaderboards/selectLeaderboard',
+      fetchLeaderboards: 'leaderboards/fetchLeaderboards',
     }),
     async submit() {
       this.processingForm = true
@@ -42,6 +43,7 @@ export default {
         name: this.name,
       }
       this.newLeadboard = await this.postLeaderboard(formData)
+      await this.fetchLeaderboards()
       console.log(this.newLeadboard);
       this.selectLeaderboard(this.newLeadboard.id)
       this.processingForm = false

--- a/src/views/LeaderboardNew.vue
+++ b/src/views/LeaderboardNew.vue
@@ -44,7 +44,6 @@ export default {
       }
       this.newLeadboard = await this.postLeaderboard(formData)
       await this.fetchLeaderboards()
-      console.log(this.newLeadboard);
       this.selectLeaderboard(this.newLeadboard.id)
       this.processingForm = false
       this.$router.push(

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -1,5 +1,9 @@
 <template>
-  <SnapNavigationLayout :items="leaderboards" ref="snapNav">
+  <SnapNavigationLayout
+    :items="leaderboards"
+    ref="snapNav"
+    @change-item="handleChangeItem"
+  >
     <template v-slot:item="{ item: leaderboard }">
       <LeaderboardRankingsCard
         :leaderboard="leaderboard"
@@ -23,13 +27,18 @@ export default {
       required: false,
     },
   },
-
+  data() {
+    return {
+      isInitialLoad: true,
+    }
+  },
   async mounted() {
     if (this.currentLeaderboard) this.$emit('init')
-
     await this.fetchLeaderboards()
-    this.$emit('init')
     const index = this.leaderboards.findIndex(l => l.id === this.currentLeaderboard.id)
+    // sets where the currentLeaderboard is
+    this.currentIndex = index
+    this.$emit('init')
     this.$refs.snapNav.goToPage(index)
   },
 
@@ -39,20 +48,31 @@ export default {
       leaderboards: 'leaderboards/leaderboards',
     }),
   },
-
   watch: {
     currentLeaderboard(leaderboard) {
       const index = this.leaderboards.findIndex(l => l.id === leaderboard.id)
       this.$refs.snapNav.goToPage(index)
     },
   },
-
   methods: {
     ...mapActions({
       selectLeaderboard: 'leaderboards/selectLeaderboard',
       fetchLeaderboards: 'leaderboards/fetchLeaderboards',
       joinLeaderboard: 'leaderboards/joinLeaderboard',
     }),
+    handleChangeItem(index) {
+      if (this.currentIndex == index) {
+        // says it's done loading when the change index hits the currentLeaderboard index
+        this.isInitialLoad = false
+      }
+      if (!this.isInitialLoad) {
+        // updates current leaderboard when not loading the page
+        this.changeLeaderboard(index)
+      }
+    },
+    changeLeaderboard(index) {
+      this.selectLeaderboard(this.leaderboards[index].id)
+    },
   },
 }
 </script>

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -1,9 +1,5 @@
 <template>
-  <SnapNavigationLayout
-    :items="leaderboards"
-    ref="snapNav"
-    @change-item="changeLeaderboard"
-  >
+  <SnapNavigationLayout :items="leaderboards" ref="snapNav">
     <template v-slot:item="{ item: leaderboard }">
       <LeaderboardRankingsCard
         :leaderboard="leaderboard"
@@ -33,6 +29,8 @@ export default {
 
     await this.fetchLeaderboards()
     this.$emit('init')
+    const index = this.leaderboards.findIndex(l => l.id === this.currentLeaderboard.id)
+    this.$refs.snapNav.goToPage(index)
   },
 
   computed: {
@@ -55,9 +53,6 @@ export default {
       fetchLeaderboards: 'leaderboards/fetchLeaderboards',
       joinLeaderboard: 'leaderboards/joinLeaderboard',
     }),
-    changeLeaderboard(index) {
-      this.selectLeaderboard(this.leaderboards[index].id)
-    },
   },
 }
 </script>

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -61,7 +61,7 @@ export default {
       joinLeaderboard: 'leaderboards/joinLeaderboard',
     }),
     handleChangeItem(index) {
-      if (this.currentIndex == index) {
+      if (this.currentIndex === index) {
         // says it's done loading when the change index hits the currentLeaderboard index
         this.isInitialLoad = false
       }


### PR DESCRIPTION
Two things fixed:
1. When you navigate away from the rankings/leaderboard page, it will return you to that same leaderboard when you return.
2. When you create a new leaderboard, it will take you to that newly created one (instead of the first one like it was doing originally).

Closes #256 