### PR TITLE
Infinite Loading After login Fix

### DIFF
--- a/src/store/modules/competitions.js
+++ b/src/store/modules/competitions.js
@@ -58,7 +58,7 @@ export const actions = {
       const competitionId =
         process.env.VUE_APP_COMPETITION_ID ||
         competitions[competitions.length - 1].id
-      dispatch('selectCompetition', competitionId)
+      await dispatch('selectCompetition', competitionId)
     }
   },
 }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -72,13 +72,18 @@ export default {
     submit() {
       this.register ? this.tryToSignUp() : this.tryToLogIn()
     },
-    tryToLogIn() {
+    async tryToLogIn() {
       this.processingForm = true
       this.authError = null
       const credentials = {
         email: this.email,
         password: this.password,
       }
+
+      if (!this.$store.getters['competitions/currentCompetitionId']) {
+        await this.$store.dispatch('competitions/setDefaultCompetition')
+      }
+
       return this.logIn(credentials)
         .then(() => {
           this.processingForm = false

--- a/src/views/layouts/DefaultLayout.vue
+++ b/src/views/layouts/DefaultLayout.vue
@@ -35,6 +35,7 @@ import Header from '@/components/Header'
 import FooterNav from '@/components/FooterNav'
 import LeaderboardSubHeader from '@/components/LeaderboardSubHeader'
 import MatchesSubHeader from '@/components/MatchesSubHeader'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -46,12 +47,28 @@ export default {
   },
 
   data() {
+    const { title, img, subHeader } = this.$route.meta
     return {
       componentInitialized: false,
-      title: this.$route.meta.title,
-      img: this.$route.meta.img,
-      subHeader: this.$route.meta.subHeader,
+      title: title,
+      img: img,
+      subHeader: subHeader,
     }
+  },
+  computed: {
+    ...mapGetters('competitions', ['currentCompetition']),
+    competitionTitle() {
+      return this.currentCompetition?.name
+    },
+  },
+  watch: {
+    '$route.meta': {
+      immediate: true,
+      handler(meta) {
+        // Temporary fix for title not updating on route change from login
+        this.title = meta.title || this.competitionTitle
+      },
+    },
   },
 }
 </script>


### PR DESCRIPTION
There's an issue when we try to set the meta title from routes.js,I think the property is not in state yet when we try to grab it, 
`title: store.getters['competitions/currentCompetition']?.name,`

it is after the page loads, that's why it works properly on refresh. We'll need to investigate the flow of the route closer, but this temporary fix should work for now (we watch for title changes and grab it from the state after its available, not before)

