### PR TITLE
made the border width thicker to see the prediction clearer

### DIFF
--- a/src/components/TeamBadge.vue
+++ b/src/components/TeamBadge.vue
@@ -30,13 +30,13 @@ export default {
     highlight() {
       switch (this.status) {
         case 'correct':
-          return 'border-4 border-prediction-correct'
+          return 'border-6 border-prediction-correct'
         case 'wrong':
-          return 'border-4 border-prediction-wrong'
+          return 'border-6 border-prediction-wrong'
         case 'selected':
-          return 'border-4 border-prediction-selected'
+          return 'border-6 border-prediction-selected'
         default:
-          return 'border-4 border-prediction-default'
+          return 'border-6 border-prediction-default'
       }
     },
   },
@@ -52,5 +52,10 @@ export default {
 }
 small {
   font-size: 0.5em;
+}
+
+// Not in Tailwind
+.border-6 {
+  border-width: 6px;
 }
 </style>

--- a/src/components/TeamBadge.vue
+++ b/src/components/TeamBadge.vue
@@ -53,9 +53,4 @@ export default {
 small {
   font-size: 0.5em;
 }
-
-// Not in Tailwind
-.border-6 {
-  border-width: 6px;
-}
 </style>


### PR DESCRIPTION
We were already using `border-6` on the draw component anyway (as you can see below)

<p float='left'>
<img width="200" alt="image" src="https://github.com/trouni/predictor-vue/assets/25542223/9a966c85-2d68-460e-bf2e-64d4bae1cf27">
<img width="200" alt="image" src="https://github.com/trouni/predictor-vue/assets/25542223/9310d3ae-2b8e-46ff-962f-0c3cdcf06769">
</p>