### PR TITLE
showing all the users who have the same rank as the top 10

### DIFF
--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -62,7 +62,7 @@ export default {
     lastRank() {
       if (this.rankedUsers.length === 0) return 0
 
-      if (typeof this.leaderboard.rankingsTopN === 'number') {
+      if (this.leaderboard.rankingsTopN) {
         return this.rankedUsers[this.leaderboard.rankingsTopN].rank
       } else {
         return this.rankedUsers[this.rankedUsers.length - 1].rank

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -19,9 +19,12 @@
           name: currentUser.name,
           userId: currentUser.id,
           photoKey: currentUser.photoKey || currentUser.photo_key,
-          points: '-',
+          points: userRank ? userRank.points : '-',
+          position: userRank ? userRank.rank : null,
         },
       ]"
+      :points="userRank ? userRank.points : '-'"
+      :position="userRank ? userRank.rank : null"
       :padding-start="true"
       :link-predictions="false"
       class="mt-1"
@@ -54,7 +57,7 @@ export default {
       return this.leaderboard.users.slice().sort((a, b) => b.points - a.points)
     },
     isCurrentUserRanked() {
-      return this.rankedUsers.some(user => user.userId === this.currentUser.id)
+      return this.rankedUsers.some(user => user.userId === this.currentUser.id && user.rank <= this.lastRank)
     },
     lastRank() {
       if (this.rankedUsers.length === 0) return 0
@@ -75,6 +78,9 @@ export default {
         }
         return accumulator
       }, [])
+    },
+    userRank() {
+      return this.sortedUsers.find(rank => rank.userId === this.currentUser.id)
     },
   },
 }

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -50,20 +50,32 @@ export default {
         return u
       })
     },
-    ranks() {
-      return this.rankedUsers.reduce((accumulator, u) => {
-        if (!accumulator.find(rank => rank.position === u.rank)) {
-          accumulator.push({ position: u.rank, points: u.points })
-        }
-        return accumulator
-      }, [])
-    },
     sortedUsers: function () {
       return this.leaderboard.users.slice().sort((a, b) => b.points - a.points)
     },
     isCurrentUserRanked() {
       return this.rankedUsers.some(user => user.userId === this.currentUser.id)
-    }
+    },
+    lastRank() {
+      if (this.rankedUsers.length === 0) return 0
+
+      if (typeof this.leaderboard.rankingsTopN === 'number') {
+        return this.rankedUsers[this.leaderboard.rankingsTopN].rank
+      } else {
+        return this.rankedUsers[this.rankedUsers.length - 1].rank
+      }
+    },
+    ranks() {
+      return this.rankedUsers.reduce((accumulator, u) => {
+        if (
+          !accumulator.find(rank => rank.position === u.rank) &&
+          u.rank <= this.lastRank
+        ) {
+          accumulator.push({ position: u.rank, points: u.points })
+        }
+        return accumulator
+      }, [])
+    },
   },
 }
 </script>

--- a/src/components/LeaderboardResults.vue
+++ b/src/components/LeaderboardResults.vue
@@ -57,7 +57,7 @@ export default {
           Object.keys(this.leaderboard.results[match.id] ?? {}).forEach(
             choice => {
               results[choice] = this.leaderboard.results[match.id][choice]
-                .map(userId => userId == this.currentUser.id ? this.rankedUsers.find(u => u.userId === userId) : this.topUsers.find(u => u.userId === userId))
+                .map(userId => userId === this.currentUser.id ? this.rankedUsers.find(u => u.userId === userId) : this.topUsers.find(u => u.userId === userId))
                 .filter(user => user !== undefined) // Filter out undefined values
             }
           )

--- a/src/components/LeaderboardResults.vue
+++ b/src/components/LeaderboardResults.vue
@@ -59,7 +59,6 @@ export default {
               results[choice] = this.leaderboard.results[match.id][choice]
                 .map(userId => userId == this.currentUser.id ? this.rankedUsers.find(u => u.userId === userId) : this.topUsers.find(u => u.userId === userId))
                 .filter(user => user !== undefined) // Filter out undefined values
-              console.log(results)
             }
           )
           predictions[match.id] = results


### PR DESCRIPTION
⚠️ This has big repercussions. In order for this to work, the [back-end PR](https://github.com/dmbf29/predictor-api/pull/121) needs to be merged as well.

Then in the front-end, we have access to all of the users. That way, if someone is ranked 12 but tied with the person who is 10th, we'll show them. And we also have access to the `currentUser`'s score and can display it if they're not in the top 10