### PR TITLE
Competition Buttons adjustment

### DIFF
--- a/src/components/CompetitionsList.vue
+++ b/src/components/CompetitionsList.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="grid grid-cols-2 gap-4">
+    <div
+      v-for="competition in competitions"
+      :key="competition.id"
+      class="mt-3 flex flex-col border rounded shadow-md"
+    >
+      <BaseLink
+        :to="{ name: 'predictions', params: { id: competition.id } }"
+        class="grow h-full"
+      >
+        <div
+          class="card-competition flex flex-col justify-center p-4 h-full"
+          @click="handleCompetitionClick(competition.id)"
+        >
+          <img
+            v-if="competition.photoUrl"
+            alt="football graphic"
+            :src="competition.photoUrl"
+            class="grow"
+          />
+        </div>
+      </BaseLink>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    competitions: {
+      type: Array,
+      required: true,
+    },
+  },
+}
+</script>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -7,7 +7,9 @@
         :src="require('../assets/' + img)"
         class="header-img"
       />
-      <h2 class="text-white" v-if="title"> {{ title }}</h2>
+      <BaseLink v-if="title" :to="{ name: 'competitions' }">
+        <h2 class="text-white"> {{ title }}</h2>
+      </BaseLink>
     </div>
     <slot />
   </div>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -182,11 +182,23 @@ export default [
             }),
             meta: {
               authRequired: true,
-              title: store.getters['competitions/currentCompetition']?.name,
+              title: 'Predictions',
               img: 'football.png',
               subHeader: 'MatchesSubHeader',
             },
             alias: '/predictions',
+            beforeEnter: async (to, from, next) => {
+              try {
+                const currentCompetition =
+                  store.getters['competitions/currentCompetition']
+                if (currentCompetition) {
+                  to.meta.title = currentCompetition.name
+                }
+              } catch (error) {
+                console.error('Error fetching current competition:', error)
+              }
+              next()
+            },
           },
         ],
       },

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -124,6 +124,18 @@ export default [
               subHeader: 'LeaderboardSubHeader',
             },
             alias: '/results',
+            beforeEnter: async (to, from, next) => {
+              try {
+                const currentCompetition =
+                  store.getters['competitions/currentCompetition']
+                if (currentCompetition) {
+                  to.meta.title = currentCompetition.name
+                }
+              } catch (error) {
+                console.error('Error fetching current competition:', error)
+              }
+              next()
+            },
           },
           {
             path: 'rankings',
@@ -137,6 +149,18 @@ export default [
               subHeader: 'LeaderboardSubHeader',
             },
             alias: '/rankings',
+            beforeEnter: async (to, from, next) => {
+              try {
+                const currentCompetition =
+                  store.getters['competitions/currentCompetition']
+                if (currentCompetition) {
+                  to.meta.title = currentCompetition.name
+                }
+              } catch (error) {
+                console.error('Error fetching current competition:', error)
+              }
+              next()
+            },
           },
           {
             path: 'predict',
@@ -210,6 +234,17 @@ export default [
         meta: {
           authRequired: true,
           title: 'Profile',
+          img: 'player.png',
+        },
+      },
+      {
+        path: '/all_competitions',
+        name: 'competitions',
+        component: () => import('@/views/Competitions'),
+        props: () => ({ id: store.getters['auth/currentUser'].id }),
+        meta: {
+          authRequired: true,
+          title: 'Competitions',
           img: 'player.png',
         },
       },

--- a/src/views/Competitions.vue
+++ b/src/views/Competitions.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="p-4 h-full flex justify-center">
+    <div class="w-full md:w-6/12">
+      <h3 class="text-center">Ongoing</h3>
+      <CompetitionsList :competitions="ongoingCompetitions" />
+      <h3 class="text-center mt-5">Past</h3>
+      <CompetitionsList :competitions="pastCompetitions" />
+    </div>
+  </div>
+</template>
+
+<script>
+import CompetitionsList from '@/components/CompetitionsList'
+import { mapGetters, mapActions } from 'vuex'
+
+export default {
+  components: { CompetitionsList },
+  props: {
+    id: {
+      type: Number,
+      required: true,
+    },
+  },
+  async mounted() {
+    this.fetchCompetitions()
+    this.user = await this.fetchUser({ userId: this.id })
+    this.$emit('init')
+  },
+  computed: {
+    ...mapGetters({
+      competitions: 'competitions/competitions',
+    }),
+    descendingCompetitions() {
+      return [...this.competitions].reverse()
+    },
+    ongoingCompetitions() {
+      return this.descendingCompetitions.filter(c => !this.competitionEnded(c.endDate))
+    },
+    pastCompetitions() {
+      return this.descendingCompetitions.filter(c => this.competitionEnded(c.endDate))
+    },
+  },
+  methods: {
+    ...mapActions({
+      fetchCompetitions: 'competitions/fetchCompetitions',
+      fetchUser: 'users/fetchUser',
+    }),
+    async handleCompetitionClick(competitionId) {
+      await this.$store.dispatch(
+        'competitions/selectCompetition',
+        competitionId
+      )
+    },
+    competitionEnded(endDate) {
+      return (
+        new Date().setHours(0, 0, 0, 0) > new Date(endDate).setHours(0, 0, 0, 0)
+      )
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles';
+
+.card-competition {
+  // background-color: white;
+}
+
+.card-competition p {
+  margin: 0;
+  color: $purple;
+}
+</style>

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -71,28 +71,8 @@
         </div>
       </div>
       <div class="w-full md:w-6/12 mt-10">
-        <h4>Competitions</h4>
-        <ul class="flex-column list-none competitions">
-          <li
-            v-for="competition in descendingCompetitions"
-            :key="competition.id"
-            class="mt-3"
-          >
-            <BaseLink
-              :to="{ name: 'predictions', params: { id: competition.id } }"
-            >
-              <BaseButton
-                class="w-full"
-                :class="
-                  competitionEnded(competition.endDate) ? 'secondary' : ''
-                "
-                @click="handleCompetitionClick(competition.id)"
-              >
-                {{ competition.name }}
-              </BaseButton>
-            </BaseLink>
-          </li>
-        </ul>
+        <h3>Switch Competition</h3>
+        <CompetitionsList :competitions="ongoingCompetitions" />
       </div>
     </div>
   </div>
@@ -102,6 +82,7 @@
 import { mapGetters, mapActions } from 'vuex'
 import { CldContext, CldImage, CldTransformation } from 'cloudinary-vue'
 import { config } from '@/constants'
+import CompetitionsList from '@/components/CompetitionsList'
 
 export default {
   props: {
@@ -114,6 +95,7 @@ export default {
     CldContext,
     CldImage,
     CldTransformation,
+    CompetitionsList,
   },
   async mounted() {
     this.fetchCompetitions()
@@ -126,8 +108,11 @@ export default {
       competitions: 'competitions/competitions',
     }),
     descendingCompetitions() {
-      return [...this.competitions].reverse(); // Create a copy of the array and reverse it
-    }
+      return [...this.competitions].reverse()
+    },
+    ongoingCompetitions() {
+      return this.descendingCompetitions.filter(c => !this.competitionEnded(c.endDate))
+    },
   },
 
   data() {

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -72,17 +72,17 @@
       </div>
       <div class="w-full md:w-6/12 mt-10">
         <h4>Competitions</h4>
-        <ul class="flex-column list-none">
+        <ul class="flex-column list-none competitions">
           <li
-            v-for="competition in competitions"
+            v-for="competition in descendingCompetitions"
             :key="competition.id"
-            class="mr-3 last:mr-0 mt-3"
+            class="mt-3"
           >
             <BaseLink
               :to="{ name: 'predictions', params: { id: competition.id } }"
             >
               <BaseButton
-                class="w-60"
+                class="w-full"
                 :class="
                   competitionEnded(competition.endDate) ? 'secondary' : ''
                 "
@@ -125,6 +125,9 @@ export default {
     ...mapGetters({
       competitions: 'competitions/competitions',
     }),
+    descendingCompetitions() {
+      return [...this.competitions].reverse(); // Create a copy of the array and reverse it
+    }
   },
 
   data() {
@@ -198,5 +201,9 @@ p {
   &:hover {
     cursor: pointer;
   }
+}
+
+.competitions a {
+  width: 100%;
 }
 </style>

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -56,7 +56,11 @@
             @keypress.enter="submit"
             @keypress="userNameUpdated = false"
           />
-          <BaseButton :disabled="processingForm" @click="submit" class="absolute top-0 right-0 h-full">
+          <BaseButton
+            :disabled="processingForm"
+            @click="submit"
+            class="absolute top-0 right-0 h-full"
+          >
             Update
           </BaseButton>
         </div>
@@ -66,16 +70,24 @@
           </BaseLink>
         </div>
       </div>
-      <div v-if="user.admin" class="w-full md:w-6/12 mt-10">
+      <div class="w-full md:w-6/12 mt-10">
         <h4>Competitions</h4>
-        <ul class="flex list-none">
+        <ul class="flex-column list-none">
           <li
             v-for="competition in competitions"
             :key="competition.id"
-            class="mr-3 last:mr-0"
+            class="mr-3 last:mr-0 mt-3"
           >
-            <BaseLink :to="{ name: 'predictions', params: { id: competition.id } }">
-              <BaseButton>
+            <BaseLink
+              :to="{ name: 'predictions', params: { id: competition.id } }"
+            >
+              <BaseButton
+                class="w-60"
+                :class="
+                  competitionEnded(competition.endDate) ? 'secondary' : ''
+                "
+                @click="handleCompetitionClick(competition.id)"
+              >
                 {{ competition.name }}
               </BaseButton>
             </BaseLink>
@@ -156,6 +168,17 @@ export default {
           }
         )
         .open()
+    },
+    competitionEnded(endDate) {
+      return (
+        new Date().setHours(0, 0, 0, 0) > new Date(endDate).setHours(0, 0, 0, 0)
+      )
+    },
+    async handleCompetitionClick(competitionId) {
+      await this.$store.dispatch(
+        'competitions/selectCompetition',
+        competitionId
+      )
     },
   },
 }

--- a/src/views/layouts/DefaultLayout.vue
+++ b/src/views/layouts/DefaultLayout.vue
@@ -35,7 +35,6 @@ import Header from '@/components/Header'
 import FooterNav from '@/components/FooterNav'
 import LeaderboardSubHeader from '@/components/LeaderboardSubHeader'
 import MatchesSubHeader from '@/components/MatchesSubHeader'
-import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -54,21 +53,6 @@ export default {
       img: img,
       subHeader: subHeader,
     }
-  },
-  computed: {
-    ...mapGetters('competitions', ['currentCompetition']),
-    competitionTitle() {
-      return this.currentCompetition?.name
-    },
-  },
-  watch: {
-    '$route.meta': {
-      immediate: true,
-      handler(meta) {
-        // Temporary fix for title not updating on route change from login
-        this.title = meta.title || this.competitionTitle
-      },
-    },
   },
 }
 </script>


### PR DESCRIPTION
Before/After
<img width="300" alt="Screenshot 2024-06-20 at 6 16 38" src="https://github.com/trouni/predictor-vue/assets/87453991/adb5a5db-013f-4e7c-938a-c38bf75c9c0a"><img width="323" alt="Screenshot 2024-06-20 at 6 16 57" src="https://github.com/trouni/predictor-vue/assets/87453991/3c9a88da-647e-4c54-aff1-f41f9fc9c5ce">

- Why did we have it only for admins? Can add it back in if needed
- Made buttons column (can update further down the line)
- Clicking on a competition sets it as the currentCompetition in state, which fetches the correct data after navigation
- Past competitions (should these be clickable?, doesn't seem to break anything) have secondary style, ongoing have primary
- Maybe we can remove 'Euro Test' from BE? 

- Investigated the previous issue a little title deeper and fixed at the root, removed temporary fix. 
I realised the 2nd screenShot shows 'Copa America' in /profile. Title comes directly from meta now. Fallback is "Predictions"

