### PR TITLE
changed all the titles to be the name of the competion which redirects to the profile page

### DIFF
--- a/src/components/CompetitionsList.vue
+++ b/src/components/CompetitionsList.vue
@@ -14,8 +14,10 @@
           @click="handleCompetitionClick(competition.id)"
         >
           <img
+            v-if="competition.photoUrl"
             alt="football graphic"
-            :src="competition.photoUrl" class="grow" key=""
+            :src="competition.photoUrl"
+            class="grow"
           />
         </div>
       </BaseLink>

--- a/src/components/CompetitionsList.vue
+++ b/src/components/CompetitionsList.vue
@@ -10,7 +10,7 @@
         class="grow h-full"
       >
         <div
-          class="card-competition flex flex-col justify-center p-2 h-full"
+          class="card-competition flex flex-col justify-center p-4 h-full"
           @click="handleCompetitionClick(competition.id)"
         >
           <img

--- a/src/components/CompetitionsList.vue
+++ b/src/components/CompetitionsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+  <div class="grid grid-cols-2 gap-4">
     <div
       v-for="competition in competitions"
       :key="competition.id"

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -8,7 +8,7 @@
         class="header-img"
       />
       <BaseLink v-if="title" :to="{ name: 'profile' }">
-        <h2 class="text-white" v-if="title"> {{ title }}</h2>
+        <h2 class="text-white"> {{ title }}</h2>
       </BaseLink>
     </div>
     <slot />

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -7,7 +7,9 @@
         :src="require('../assets/' + img)"
         class="header-img"
       />
-      <h2 class="text-white" v-if="title"> {{ title }}</h2>
+      <BaseLink v-if="title" :to="{ name: 'profile' }">
+        <h2 class="text-white" v-if="title"> {{ title }}</h2>
+      </BaseLink>
     </div>
     <slot />
   </div>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -124,6 +124,18 @@ export default [
               subHeader: 'LeaderboardSubHeader',
             },
             alias: '/results',
+            beforeEnter: async (to, from, next) => {
+              try {
+                const currentCompetition =
+                  store.getters['competitions/currentCompetition']
+                if (currentCompetition) {
+                  to.meta.title = currentCompetition.name
+                }
+              } catch (error) {
+                console.error('Error fetching current competition:', error)
+              }
+              next()
+            },
           },
           {
             path: 'rankings',
@@ -137,6 +149,18 @@ export default [
               subHeader: 'LeaderboardSubHeader',
             },
             alias: '/rankings',
+            beforeEnter: async (to, from, next) => {
+              try {
+                const currentCompetition =
+                  store.getters['competitions/currentCompetition']
+                if (currentCompetition) {
+                  to.meta.title = currentCompetition.name
+                }
+              } catch (error) {
+                console.error('Error fetching current competition:', error)
+              }
+              next()
+            },
           },
           {
             path: 'predict',

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -238,7 +238,7 @@ export default [
         },
       },
       {
-        path: '/competitions',
+        path: '/all_competitions',
         name: 'competitions',
         component: () => import('@/views/Competitions'),
         props: () => ({ id: store.getters['auth/currentUser'].id }),

--- a/src/views/Competitions.vue
+++ b/src/views/Competitions.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="p-4">
-    <h3 class="text-center">Ongoing</h3>
-    <CompetitionsList :competitions="ongoingCompetitions" />
-    <h3 class="text-center mt-5">Past</h3>
-    <CompetitionsList :competitions="pastCompetitions" />
+  <div class="p-4 h-full flex justify-center">
+    <div class="w-full md:w-6/12">
+      <h3 class="text-center">Ongoing</h3>
+      <CompetitionsList :competitions="ongoingCompetitions" />
+      <h3 class="text-center mt-5">Past</h3>
+      <CompetitionsList :competitions="pastCompetitions" />
+    </div>
   </div>
 </template>
 

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -126,8 +126,8 @@ export default {
       competitions: 'competitions/competitions',
     }),
     descendingCompetitions() {
-      return [...this.competitions].reverse(); // Create a copy of the array and reverse it
-    }
+      return [...this.competitions].reverse()
+    },
   },
 
   data() {

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -71,7 +71,7 @@
         </div>
       </div>
       <div class="w-full md:w-6/12 mt-10">
-        <h4>Competitions</h4>
+        <h3>Switch Competition</h3>
         <ul class="flex-column list-none competitions">
           <li
             v-for="competition in descendingCompetitions"


### PR DESCRIPTION
⚠️ I'm merging this one into @Netsujr 's previous PR #263 so best to approve and merge this one first

changed all the titles to be the name of the competion which redirects to the profile page to the profile page (for now) where you can switch comepitions.

<img width="200" alt="image" src="https://github.com/trouni/predictor-vue/assets/25542223/53276c9e-7677-434e-9425-288515d832fd">
<img width="200" alt="image" src="https://github.com/trouni/predictor-vue/assets/25542223/c6e5c946-2285-4904-bb8c-7e49e154dd19">
