### PR TITLE
Fetch correct User info when checking (own) User profile

### DIFF
--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -19,12 +19,12 @@
           name: currentUser.name,
           userId: currentUser.id,
           photoKey: currentUser.photoKey || currentUser.photo_key,
-          points: userRank ? userRank.points : '-',
-          position: userRank ? userRank.rank : null,
+          points: getPoints,
+          position: getPosition,
         },
       ]"
-      :points="userRank ? userRank.points : '-'"
-      :position="userRank ? userRank.rank : null"
+      :points="getPoints"
+      :position="getPosition"
       :padding-start="true"
       :link-predictions="false"
       class="mt-1"
@@ -48,16 +48,23 @@ export default {
   computed: {
     ...mapGetters({ currentUser: 'auth/currentUser' }),
     rankedUsers() {
-      return this.sortedUsers.map(u => {
-        u.rank = this.sortedUsers.findIndex(usr => u.points === usr.points) + 1
-        return u
+      return this.sortedUsers.map(user => {
+        user.rank =
+          this.sortedUsers.findIndex(usr => user.points === usr.points) + 1
+        return user
       })
     },
-    sortedUsers: function () {
+    sortedUsers() {
       return this.leaderboard.users.slice().sort((a, b) => b.points - a.points)
     },
     isCurrentUserRanked() {
       return this.rankedUsers.some(user => user.userId === this.currentUser.id && user.rank <= this.lastRank)
+    },
+    getPoints() {
+      return this.userRank ? this.userRank.points : '-'
+    },
+    getPosition() {
+      return this.userRank ? this.userRank.rank : null
     },
     lastRank() {
       if (this.rankedUsers.length === 0) return 0

--- a/src/store/modules/users.js
+++ b/src/store/modules/users.js
@@ -20,12 +20,15 @@ export const mutations = {
 }
 
 export const actions = {
-  fetchUser({ commit, state, rootState }, { userId, competitionId }) {
+  fetchUser(
+    { commit, state, rootState },
+    { userId, competitionId, ownPredictions }
+  ) {
     // 1. Check if we already have the user as a current user.
     const { currentUser } = rootState.auth
     const { currentCompetitionId } = rootState.competitions
     competitionId = competitionId || currentCompetitionId
-    if (currentUser && currentUser.id === userId) {
+    if (currentUser && currentUser.id === userId && !ownPredictions) {
       return Promise.resolve(currentUser)
     }
 

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -82,7 +82,10 @@ export default {
 
   async mounted() {
     if (this.userId) {
-      this.user = await this.fetchUser({ userId: this.userId })
+      this.user = await this.fetchUser({
+        userId: this.userId,
+        ownPredictions: true,
+      })
       // Removing 'UPCOMING' for other users' pages
       const upcomingIndex = this.tabs.indexOf('upcoming')
       this.tabs.splice(upcomingIndex, 1)


### PR DESCRIPTION
1. seems we have 2 types of User objects, that contains slightly different info. Lets call em CurrentUser, and userProfile
<img width="276" alt="Screenshot 2024-06-21 at 6 24 05" src="https://github.com/trouni/predictor-vue/assets/87453991/9f9997f0-cba9-4b82-aa48-21730a6637ec">
<img width="270" alt="Screenshot 2024-06-21 at 6 23 09" src="https://github.com/trouni/predictor-vue/assets/87453991/a66d4bd5-75fc-48dc-939e-94105b4c92d4">

(left), currentUser does not have the info we need for checking your own prediction page (points/possiblePoints)
In the fetchUser() action, we were resolving the Promise if the currentUserId matches with the user being fetched. Negating the correct fetch of the userProfile obj. I added a property to not do that on Predictions page. Should work as normal in the other 2 areas we use fetchUser, where we don't pass this property (`Competitions/UserProfile`). Please do some testing / clicking around, making sure we correctly fetch  images, data, email  etc.. is being fetched properly. Worked okay on my end

<img width="300" alt="Screenshot 2024-06-21 at 6 25 19" src="https://github.com/trouni/predictor-vue/assets/87453991/c0c8a45f-0fce-4afa-9e99-cf29d9ba59e4">
<img width="300" alt="Screenshot 2024-06-21 at 6 25 08" src="https://github.com/trouni/predictor-vue/assets/87453991/f050cb49-7ce2-4139-8f72-faf8a48cd508">

2. Refactored some code in `LeaderboardRankingCard`
3. In some cases, For example, in the global top leaderboard, I think when we are at the bottom of the leaderboard and not officially in the "Top 10", I couldn't click on my own profile. We'll probably need a minor adjustment on how we handle the `:to` on profile click. It worked okay when I removed this line `:disabled="!linkPredictions"` from `LeaderboardRanking.vue`, but didn't dig too deep why it was there in the first place. 
