### PR TITLE
added a way to see users w/o predictions and a placeholder for the global leaderboard

### DIFF
--- a/src/components/LeaderboardRanking.vue
+++ b/src/components/LeaderboardRanking.vue
@@ -68,12 +68,15 @@
 
       <!-- Points -->
       <div class="flex-shrink-0 text-right">
-        <p class="font-black leading-none" :class="pointsFontClass" style="color: #fa5151">
-          {{ userRankings[0].points }}
-        </p>
-        <p v-if="userRankings[0].possiblePoints" class="text-xs text-gray-400 font-normal mt-0.5">
-          / {{ userRankings[0].possiblePoints }}
-        </p>
+        <template v-if="userRankings[0].totalPredictions || userRankings[0].total_predictions">
+          <p class="font-black leading-none" :class="pointsFontClass" style="color: #fa5151">
+            {{ userRankings[0].points }}
+          </p>
+          <p v-if="userRankings[0].possiblePoints" class="text-xs text-gray-400 font-normal mt-0.5">
+            / {{ userRankings[0].possiblePoints }}
+          </p>
+        </template>
+        <p v-else class="text-xs text-gray-400 italic font-normal leading-none">yet to predict</p>
       </div>
 
     </div>

--- a/src/components/LeaderboardRanking.vue
+++ b/src/components/LeaderboardRanking.vue
@@ -68,7 +68,13 @@
 
       <!-- Points -->
       <div class="flex-shrink-0 text-right">
-        <template v-if="userRankings[0].totalPredictions || userRankings[0].total_predictions">
+        <template
+          v-if="
+            userRankings.some(
+              r => (r.totalPredictions || r.total_predictions) > 0
+            )
+          "
+        >
           <p class="font-black leading-none" :class="pointsFontClass" style="color: #fa5151">
             {{ userRankings[0].points }}
           </p>

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -1,39 +1,66 @@
 <template>
   <div class="flex flex-col gap-1.5">
-    <!-- Ranked rows -->
-    <LeaderboardRanking
-      v-for="{ position, points } in ranks"
-      :key="position"
-      :userRankings="usersAtRank(position)"
-      :position="position"
-      :link-predictions="true"
-      :points="points"
-    />
-
-    <!-- "Your position" strip — shown when current user is outside the visible ranks -->
-    <template v-if="!isCurrentUserVisible && currentUserEntry">
-      <!-- Visual separator -->
-      <div class="flex items-center gap-3 px-4 py-1">
-        <div class="flex-1 border-t border-dashed border-white/40" />
-        <span class="text-white/40 text-xs font-medium">your position</span>
-        <div class="flex-1 border-t border-dashed border-white/40" />
+    <!-- Pre-tournament placeholder for the Global (auto-join) leaderboard -->
+    <div
+      v-if="showPreTournamentPlaceholder"
+      class="bg-white rounded-2xl shadow-sm w-full px-6 py-8 text-center"
+    >
+      <div class="text-4xl mb-3">🏆</div>
+      <h3 class="font-bold text-gray-800 text-lg mb-1">
+        {{ leaderboard.name }}
+      </h3>
+      <p class="text-gray-500 text-sm mb-5">{{ leaderboard.description }}</p>
+      <div
+        class="inline-flex items-center gap-2 bg-gray-100 rounded-full px-4 py-2 mb-5"
+      >
+        <span class="font-semibold text-gray-700 text-sm">
+          {{ playerCount }}
+        </span>
+        <span class="text-gray-500 text-sm">players signed up</span>
       </div>
+      <p class="text-gray-400 text-xs leading-relaxed">
+        Rankings will appear here once the tournament kicks off and predictions
+        start rolling in. The top {{ leaderboard.rankingsTopN || 10 }} players
+        will be shown.
+      </p>
+    </div>
 
+    <!-- Ranked rows -->
+    <template v-else>
       <LeaderboardRanking
-        :userRankings="[
-          {
-            userId: currentUser.id,
-            id: currentUser.id,
-            name: currentUser.name,
-            photoKey: currentUser.photoKey || currentUser.photo_key,
-            points: currentUserEntry.points,
-            rank: currentUserEntry.rank,
-          },
-        ]"
-        :position="currentUserEntry.rank || null"
-        :padding-start="true"
-        :link-predictions="false"
+        v-for="{ position, points } in ranks"
+        :key="position"
+        :userRankings="usersAtRank(position)"
+        :position="position"
+        :link-predictions="true"
+        :points="points"
       />
+
+      <!-- "Your position" strip — shown when current user is outside the visible ranks -->
+      <template v-if="!isCurrentUserVisible && currentUserEntry">
+        <!-- Visual separator -->
+        <div class="flex items-center gap-3 px-4 py-1">
+          <div class="flex-1 border-t border-dashed border-white/40" />
+          <span class="text-white/40 text-xs font-medium">your position</span>
+          <div class="flex-1 border-t border-dashed border-white/40" />
+        </div>
+
+        <LeaderboardRanking
+          :userRankings="[
+            {
+              userId: currentUser.id,
+              id: currentUser.id,
+              name: currentUser.name,
+              photoKey: currentUser.photoKey || currentUser.photo_key,
+              points: currentUserEntry.points,
+              rank: currentUserEntry.rank,
+            },
+          ]"
+          :position="currentUserEntry.rank || null"
+          :padding-start="true"
+          :link-predictions="false"
+        />
+      </template>
     </template>
 
     <!-- Actions -->
@@ -59,7 +86,20 @@ export default {
   },
 
   computed: {
-    ...mapGetters({ currentUser: 'auth/currentUser' }),
+    ...mapGetters({
+      currentUser: 'auth/currentUser',
+      currentCompetition: 'competitions/currentCompetition',
+    }),
+
+    showPreTournamentPlaceholder() {
+      if (!this.leaderboard.autoJoin) return false
+      if (!this.currentCompetition?.startDate) return false
+      return new Date(this.currentCompetition.startDate) > new Date()
+    },
+
+    playerCount() {
+      return (this.leaderboard.users || []).length
+    },
 
     sortedUsers() {
       const users = (this.leaderboard.users || []).slice()


### PR DESCRIPTION
⚠️⚠️⚠️ This needs the [back-end PR](https://github.com/dmbf29/predictor-api/pull/133) to be merged along with it. ⚠️⚠️⚠️

### Two big changes:

1. Before, the leaderboard would only show players who have made predictions. So when you joined a group, you wouldnt see your name (or any others who didnt pick). Now it says "not yet picked"
Before/After
<table>
<tr>
<td><img width="355" alt="image" src="https://github.com/user-attachments/assets/265a2a2a-3555-4906-9b52-f5b9ef34fd7b" /></td>
<td><img width="355" height="768" alt="image" src="https://github.com/user-attachments/assets/4c6cfe46-c321-424f-85a9-da3132b45bc5" /></td>
</tr>
</table>

2. At the beginning of the tournament, everyone has the same score. So it was showing everyone on the Global Top 10. Now there is a placeholder until the tournament starts:
Before/After
<table>
<tr>
<td>
<img width="355" alt="image" src="https://github.com/user-attachments/assets/6bd1c494-9ba8-4826-bddb-097438b5c2f7" />
</td>
<td>
<img width="355" alt="image" src="https://github.com/user-attachments/assets/360471dd-d017-4ee6-b480-b67b84e5be0f" />
</td>
</tr>
</table>