### PR TITLE
it wasnt opening in production

### DIFF
--- a/src/views/ForgotPassword.vue
+++ b/src/views/ForgotPassword.vue
@@ -131,7 +131,7 @@ export default {
       try {
         await this.$store.dispatch('auth/resetPassword', {
           email: this.email,
-          redirectUrl: `http://${window.location.host}/reset-password`,
+          redirectUrl: `${window.location.origin}/reset-password`,
         })
         this.success = true
       } catch (errors) {


### PR DESCRIPTION
It hardcodes http://, so in production the redirect_url in the email becomes http://www.octacle.app/reset-password. The Rails/Devise Token Auth backend then redirects the browser to that HTTP URL, which your server likely either blocks or redirects away from — leaving a white page instead of loading the Vue app with the token params.

The fix is to use window.location.origin instead, which always captures the correct protocol: