### PR TITLE
Added group tabs for predictions and results

### DIFF
--- a/src/components/LeaderboardResults.vue
+++ b/src/components/LeaderboardResults.vue
@@ -1,5 +1,22 @@
 <template>
   <div>
+    <!-- ─── Group filter chips ─── -->
+    <div v-if="groupFilters.length > 1" class="px-4 mb-1 overflow-x-auto scrollbar-hide">
+      <div class="flex gap-2 w-max">
+        <button
+          v-for="filter in groupFilters"
+          :key="filter.key"
+          @click="selectedGroup = filter.key"
+          class="py-1 px-3 rounded-full text-xs font-semibold transition-all duration-200 focus:outline-none whitespace-nowrap"
+          :class="selectedGroup === filter.key
+            ? 'text-white chip-active'
+            : 'text-white/50 chip-inactive'"
+        >
+          {{ filter.label }}
+        </button>
+      </div>
+    </div>
+
     <MatchesGrouping
       :matches="matchesWithResults"
       :selectable="false"
@@ -32,20 +49,46 @@ export default {
     },
   },
 
+  data() {
+    return {
+      selectedGroup: null,
+    }
+  },
+
   computed: {
     ...mapGetters({
       matches: 'matches/matches',
       currentUser: 'auth/currentUser',
     }),
+    resultMatches() {
+      return this.matches
+        .filter(m => m.status === 'finished' || m.status === 'started')
+        .sort((m1, m2) => new Date(m2.kickoffTime) - new Date(m1.kickoffTime))
+    },
+    groupFilters() {
+      const roundLabel = n => {
+        if (n >= 7) return 'Final'
+        if (n === 6) return '3rd Place'
+        if (n === 5) return 'Semi-Final'
+        if (n === 4) return 'Quarter-Final'
+        if (n === 3) return 'Round of 16'
+        if (n === 2) return 'Round of 32'
+        return `Round ${n}`
+      }
+      const seen = new Map()
+      this.resultMatches.forEach(m => {
+        if (m.groupId && !seen.has(`g:${m.groupId}`))
+          seen.set(`g:${m.groupId}`, { key: `g:${m.groupId}`, label: m.groupName })
+        else if (!m.groupId && m.roundNumber && !seen.has(`r:${m.roundNumber}`))
+          seen.set(`r:${m.roundNumber}`, { key: `r:${m.roundNumber}`, label: roundLabel(m.roundNumber) })
+      })
+      if (seen.size <= 1) return []
+      const groups = [...seen.values()].filter(f => f.key.startsWith('g:')).sort((a, b) => a.label.localeCompare(b.label))
+      const rounds = [...seen.values()].filter(f => f.key.startsWith('r:')).sort((a, b) => Number(a.key.slice(2)) - Number(b.key.slice(2)))
+      return [{ key: null, label: 'All' }, ...groups, ...rounds]
+    },
     matchesWithResults() {
-      return groupBy(
-        this.matches
-          .filter(m => m.status === 'finished' || m.status === 'started')
-          .sort(
-            (m1, m2) => new Date(m2.kickoffTime) - new Date(m1.kickoffTime)
-          ),
-        m => formatDate(new Date(m.kickoffTime))
-      )
+      return groupBy(this.applyGroupFilter(this.resultMatches), m => formatDate(new Date(m.kickoffTime)))
     },
     predictions() {
       const predictions = {}
@@ -83,6 +126,21 @@ export default {
       return Object.keys(this.matchesWithResults).length === 0
     },
   },
+
+  methods: {
+    applyGroupFilter(matches) {
+      if (!this.selectedGroup) return matches
+      if (this.selectedGroup.startsWith('g:')) {
+        const id = this.selectedGroup.slice(2)
+        return matches.filter(m => String(m.groupId) === id)
+      }
+      if (this.selectedGroup.startsWith('r:')) {
+        const num = Number(this.selectedGroup.slice(2))
+        return matches.filter(m => !m.groupId && m.roundNumber === num)
+      }
+      return matches
+    },
+  },
 }
 </script>
 
@@ -91,5 +149,16 @@ export default {
 @import "@/styles";
 .results-placeholder p {
   color: rgba(255, 255, 255, 0.38);
+}
+.chip-active {
+  background-color: rgba(255, 255, 255, 0.18);
+}
+.chip-inactive {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar { display: none; }
 }
 </style>

--- a/src/components/LeaderboardResults.vue
+++ b/src/components/LeaderboardResults.vue
@@ -8,7 +8,7 @@
       <div class="flex gap-2 w-max">
         <button
           v-for="filter in groupFilters"
-          :key="filter.key"
+          :key="filter.key === null ? '__all__' : filter.key"
           @click="selectedGroup = filter.key"
           class="py-1 px-3 rounded-full text-xs font-semibold transition-all duration-200 focus:outline-none whitespace-nowrap"
           :class="

--- a/src/components/LeaderboardResults.vue
+++ b/src/components/LeaderboardResults.vue
@@ -1,16 +1,21 @@
 <template>
   <div>
     <!-- ─── Group filter chips ─── -->
-    <div v-if="groupFilters.length > 1" class="px-4 mb-1 overflow-x-auto scrollbar-hide">
+    <div
+      v-if="groupFilters.length > 1"
+      class="px-4 mb-1 overflow-x-auto scrollbar-hide"
+    >
       <div class="flex gap-2 w-max">
         <button
           v-for="filter in groupFilters"
           :key="filter.key"
           @click="selectedGroup = filter.key"
           class="py-1 px-3 rounded-full text-xs font-semibold transition-all duration-200 focus:outline-none whitespace-nowrap"
-          :class="selectedGroup === filter.key
-            ? 'text-white chip-active'
-            : 'text-white/50 chip-inactive'"
+          :class="
+            selectedGroup === filter.key
+              ? 'text-white chip-active'
+              : 'text-white/50 chip-inactive'
+          "
         >
           {{ filter.label }}
         </button>
@@ -34,7 +39,11 @@
 
 <script>
 import groupBy from 'lodash/groupBy'
-import { formatDate } from '@/utils/helpers'
+import {
+  formatDate,
+  buildGroupFilters,
+  applyGroupFilter,
+} from '@/utils/helpers'
 import { mapGetters } from 'vuex'
 import MatchesGrouping from '@/components/MatchesGrouping'
 import EmptyState from '@/components/EmptyState'
@@ -66,29 +75,13 @@ export default {
         .sort((m1, m2) => new Date(m2.kickoffTime) - new Date(m1.kickoffTime))
     },
     groupFilters() {
-      const roundLabel = n => {
-        if (n >= 7) return 'Final'
-        if (n === 6) return '3rd Place'
-        if (n === 5) return 'Semi-Final'
-        if (n === 4) return 'Quarter-Final'
-        if (n === 3) return 'Round of 16'
-        if (n === 2) return 'Round of 32'
-        return `Round ${n}`
-      }
-      const seen = new Map()
-      this.resultMatches.forEach(m => {
-        if (m.groupId && !seen.has(`g:${m.groupId}`))
-          seen.set(`g:${m.groupId}`, { key: `g:${m.groupId}`, label: m.groupName })
-        else if (!m.groupId && m.roundNumber && !seen.has(`r:${m.roundNumber}`))
-          seen.set(`r:${m.roundNumber}`, { key: `r:${m.roundNumber}`, label: roundLabel(m.roundNumber) })
-      })
-      if (seen.size <= 1) return []
-      const groups = [...seen.values()].filter(f => f.key.startsWith('g:')).sort((a, b) => a.label.localeCompare(b.label))
-      const rounds = [...seen.values()].filter(f => f.key.startsWith('r:')).sort((a, b) => Number(a.key.slice(2)) - Number(b.key.slice(2)))
-      return [{ key: null, label: 'All' }, ...groups, ...rounds]
+      return buildGroupFilters(this.resultMatches)
     },
     matchesWithResults() {
-      return groupBy(this.applyGroupFilter(this.resultMatches), m => formatDate(new Date(m.kickoffTime)))
+      return groupBy(
+        applyGroupFilter(this.resultMatches, this.selectedGroup),
+        m => formatDate(new Date(m.kickoffTime))
+      )
     },
     predictions() {
       const predictions = {}
@@ -98,7 +91,11 @@ export default {
           Object.keys(this.leaderboard.results[match.id] ?? {}).forEach(
             choice => {
               results[choice] = this.leaderboard.results[match.id][choice]
-                .map(userId => userId === this.currentUser.id ? this.rankedUsers.find(u => u.userId === userId) : this.topUsers.find(u => u.userId === userId))
+                .map(userId =>
+                  userId === this.currentUser.id
+                    ? this.rankedUsers.find(u => u.userId === userId)
+                    : this.topUsers.find(u => u.userId === userId)
+                )
                 .filter(user => user !== undefined) // Filter out undefined values
             }
           )
@@ -127,26 +124,12 @@ export default {
     },
   },
 
-  methods: {
-    applyGroupFilter(matches) {
-      if (!this.selectedGroup) return matches
-      if (this.selectedGroup.startsWith('g:')) {
-        const id = this.selectedGroup.slice(2)
-        return matches.filter(m => String(m.groupId) === id)
-      }
-      if (this.selectedGroup.startsWith('r:')) {
-        const num = Number(this.selectedGroup.slice(2))
-        return matches.filter(m => !m.groupId && m.roundNumber === num)
-      }
-      return matches
-    },
-  },
+  methods: {},
 }
 </script>
 
-
 <style lang="scss" scoped>
-@import "@/styles";
+@import '@/styles';
 .results-placeholder p {
   color: rgba(255, 255, 255, 0.38);
 }
@@ -159,6 +142,8 @@ export default {
 .scrollbar-hide {
   -ms-overflow-style: none;
   scrollbar-width: none;
-  &::-webkit-scrollbar { display: none; }
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 </style>

--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -81,9 +81,12 @@
       </p>
       <p
         v-if="match.location && match.status !== 'started'"
-        class="ml-2 text-white/70 text-xs"
+        class="ml-4 text-white/70 text-xs"
       >
-        <BaseIcon name="map-pin" /> {{ match.location }}
+        <BaseIcon name="map-pin" class="font-bold text-white" /> {{ match.location }}
+      </p>
+      <p v-if="match.groupName" class="ml-4 text-white/70 text-xs">
+        <BaseIcon name="people-group" class="font-bold text-white" /> {{ match.groupName }}
       </p>
     </div>
   </div>

--- a/src/components/MatchesGrouping.vue
+++ b/src/components/MatchesGrouping.vue
@@ -4,7 +4,7 @@
       <div v-if="dayMatches.length">
         <h4
           v-if="date !== formatDate(new Date())"
-          class="text-center font-light mt-8 mb-2 text-white"
+          class="text-center font-light mt-5 mb-2 text-white"
           >{{ date }}
         </h4>
         <template v-for="match in dayMatches">

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -67,11 +67,59 @@ export function ordinalize(num) {
   const mod100 = n % 100
   if (mod100 >= 11 && mod100 <= 13) return `${n}<sup>th</sup>`
   switch (n % 10) {
-    case 1: return `${n}<sup>st</sup>`
-    case 2: return `${n}<sup>nd</sup>`
-    case 3: return `${n}<sup>rd</sup>`
-    default: return `${n}<sup>th</sup>`
+    case 1:
+      return `${n}<sup>st</sup>`
+    case 2:
+      return `${n}<sup>nd</sup>`
+    case 3:
+      return `${n}<sup>rd</sup>`
+    default:
+      return `${n}<sup>th</sup>`
   }
+}
+
+export function roundLabel(n) {
+  if (n >= 7) return 'Final'
+  if (n === 6) return '3rd Place'
+  if (n === 5) return 'Semi-Final'
+  if (n === 4) return 'Quarter-Final'
+  if (n === 3) return 'Round of 16'
+  if (n === 2) return 'Round of 32'
+  return `Round ${n}`
+}
+
+export function buildGroupFilters(matches) {
+  const seen = new Map()
+  matches.forEach(m => {
+    if (m.groupId && !seen.has(`g:${m.groupId}`))
+      seen.set(`g:${m.groupId}`, { key: `g:${m.groupId}`, label: m.groupName })
+    else if (!m.groupId && m.roundNumber && !seen.has(`r:${m.roundNumber}`))
+      seen.set(`r:${m.roundNumber}`, {
+        key: `r:${m.roundNumber}`,
+        label: roundLabel(m.roundNumber),
+      })
+  })
+  if (seen.size <= 1) return []
+  const groups = [...seen.values()]
+    .filter(f => f.key.startsWith('g:'))
+    .sort((a, b) => a.label.localeCompare(b.label))
+  const rounds = [...seen.values()]
+    .filter(f => f.key.startsWith('r:'))
+    .sort((a, b) => Number(a.key.slice(2)) - Number(b.key.slice(2)))
+  return [{ key: null, label: 'All' }, ...groups, ...rounds]
+}
+
+export function applyGroupFilter(matches, selectedGroup) {
+  if (!selectedGroup) return matches
+  if (selectedGroup.startsWith('g:')) {
+    const id = selectedGroup.slice(2)
+    return matches.filter(m => String(m.groupId) === id)
+  }
+  if (selectedGroup.startsWith('r:')) {
+    const num = Number(selectedGroup.slice(2))
+    return matches.filter(m => !m.groupId && m.roundNumber === num)
+  }
+  return matches
 }
 
 export function formatDuration(duration) {

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -1,17 +1,19 @@
 <template>
   <div class="pb-24">
-
     <!-- ─── Viewing another user's predictions ─── -->
     <div v-if="userId" class="px-4 pt-4 mb-6">
       <button
         @click="$router.go(-1)"
         class="flex items-center gap-1.5 text-sm font-medium mb-6 transition-opacity hover:opacity-70 focus:outline-none"
-        style="color: rgba(255,255,255,0.7)"
+        style="color: rgba(255, 255, 255, 0.7)"
       >
         <BaseIcon name="chevron-left" />
         Back to Rankings
       </button>
-      <p class="text-center font-medium mb-3" style="color: rgba(255,255,255,0.6)">
+      <p
+        class="text-center font-medium mb-3"
+        style="color: rgba(255, 255, 255, 0.6)"
+      >
         Predictions made by
       </p>
       <LeaderboardRanking :userRankings="[user]" class="m-auto max-w-xs" />
@@ -19,25 +21,37 @@
 
     <!-- ─── Current user: action banner ─── -->
     <div v-else class="px-4 pt-4 mb-6">
-
       <!-- Has unpredicted matches -->
       <div
         v-if="nextMissingMatch"
         class="rounded-2xl overflow-hidden shadow-xl"
-        style="background: linear-gradient(135deg, rgba(255,255,255,0.92), rgba(255,255,255,0.78))"
+        style="
+          background: linear-gradient(
+            135deg,
+            rgba(255, 255, 255, 0.92),
+            rgba(255, 255, 255, 0.78)
+          );
+        "
       >
         <div class="px-5 pt-4 pb-3">
           <div class="flex items-stretch justify-between gap-3">
             <div>
               <p
                 class="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-1.5"
-                >Up Next</p>
+                >Up Next</p
+              >
               <div
                 class="font-bold text-gray-800 text-base leading-tight flex items-center"
               >
-                <TeamBadge options="h-10 w-10 mr-1 border-blue" :flag="nextMissingMatch.teamHome.badgeUrl" />
+                <TeamBadge
+                  options="h-10 w-10 mr-1 border-blue"
+                  :flag="nextMissingMatch.teamHome.badgeUrl"
+                />
                 vs
-                <TeamBadge options="h-10 w-10 ml-1 border-blue" :flag="nextMissingMatch.teamAway.badgeUrl" />
+                <TeamBadge
+                  options="h-10 w-10 ml-1 border-blue"
+                  :flag="nextMissingMatch.teamAway.badgeUrl"
+                />
               </div>
             </div>
             <div class="flex flex-col justify-between items-end">
@@ -68,7 +82,6 @@
               </p>
             </div>
           </div>
-
         </div>
         <div class="px-5 pb-4">
           <BaseLink
@@ -86,7 +99,13 @@
       <div
         v-else
         class="rounded-2xl px-5 py-4 flex items-center gap-4"
-        style="background: linear-gradient(135deg, rgba(255,255,255,0.92), rgba(255,255,255,0.78))"
+        style="
+          background: linear-gradient(
+            135deg,
+            rgba(255, 255, 255, 0.92),
+            rgba(255, 255, 255, 0.78)
+          );
+        "
       >
         <div
           class="flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center shadow"
@@ -96,7 +115,9 @@
         </div>
         <div class="flex-1">
           <p class="font-bold text-gray-800 text-base">All predictions in!</p>
-          <p class="text-sm text-gray-500">You've predicted all upcoming matches.</p>
+          <p class="text-sm text-gray-500"
+            >You've predicted all upcoming matches.</p
+          >
         </div>
         <BaseLink
           :to="{ name: 'edit_predictions' }"
@@ -105,23 +126,24 @@
           Edit
         </BaseLink>
       </div>
-
     </div>
 
     <!-- ─── Tabs ─── -->
     <div class="px-4 mb-1">
       <div
         class="flex rounded-2xl p-1 gap-1"
-        style="background: rgba(0,0,0,0.15)"
+        style="background: rgba(0, 0, 0, 0.15)"
       >
         <button
           v-for="tab in tabs"
           :key="tab"
           @click="changeTab(tab)"
           class="flex-1 py-2 px-3 rounded-xl text-sm font-semibold capitalize transition-all duration-200 focus:outline-none"
-          :class="selectedTab === tab
-            ? 'bg-tab text-white shadow-sm'
-            : 'text-white/60 hover:text-white/80'"
+          :class="
+            selectedTab === tab
+              ? 'bg-tab text-white shadow-sm'
+              : 'text-white/60 hover:text-white/80'
+          "
         >
           {{ tab }}
         </button>
@@ -129,16 +151,21 @@
     </div>
 
     <!-- ─── Group filter chips ─── -->
-    <div v-if="groupFilters.length > 1" class="px-4 mt-2 mb-1 overflow-x-auto scrollbar-hide">
+    <div
+      v-if="groupFilters.length > 1"
+      class="px-4 mt-2 mb-1 overflow-x-auto scrollbar-hide"
+    >
       <div class="flex gap-2 w-max">
         <button
           v-for="filter in groupFilters"
           :key="filter.key"
           @click="selectedGroup = filter.key"
           class="py-1 px-3 rounded-full text-xs font-semibold transition-all duration-200 focus:outline-none whitespace-nowrap"
-          :class="selectedGroup === filter.key
-            ? 'text-white chip-active'
-            : 'text-white/50 chip-inactive'"
+          :class="
+            selectedGroup === filter.key
+              ? 'text-white chip-active'
+              : 'text-white/50 chip-inactive'
+          "
         >
           {{ filter.label }}
         </button>
@@ -167,7 +194,6 @@
       title="No results yet"
       subtitle="Completed matches will appear here once the whistle blows."
     />
-
   </div>
 </template>
 
@@ -178,7 +204,13 @@ import LeaderboardRanking from '@/components/LeaderboardRanking'
 import TeamBadge from '@/components/TeamBadge'
 import { mapGetters, mapActions } from 'vuex'
 import { authComputed } from '@/store/helpers'
-import { pluralize, formatDate, formatDuration } from '@/utils/helpers'
+import {
+  pluralize,
+  formatDate,
+  formatDuration,
+  buildGroupFilters,
+  applyGroupFilter,
+} from '@/utils/helpers'
 import groupBy from 'lodash/groupBy'
 
 export default {
@@ -245,7 +277,9 @@ export default {
       return this.matches.some(m => m.status === 'finished')
     },
     hasUpcomingPredictions() {
-      return this.matches.some(m => m.status === 'upcoming' && 'prediction' in m)
+      return this.matches.some(
+        m => m.status === 'upcoming' && 'prediction' in m
+      )
     },
     missingPredictions() {
       return this.matches.filter(
@@ -269,31 +303,16 @@ export default {
       return this.upcomingMatches()
     },
     tabMatches() {
-      if (this.selectedTab === 'ongoing') return this.matches.filter(m => m.status === 'started')
-      if (this.selectedTab === 'past') return this.matches.filter(m => m.status === 'finished')
-      return this.matches.filter(m => m.status === 'upcoming' && 'prediction' in m)
+      if (this.selectedTab === 'ongoing')
+        return this.matches.filter(m => m.status === 'started')
+      if (this.selectedTab === 'past')
+        return this.matches.filter(m => m.status === 'finished')
+      return this.matches.filter(
+        m => m.status === 'upcoming' && 'prediction' in m
+      )
     },
     groupFilters() {
-      const roundLabel = n => {
-        if (n >= 7) return 'Final'
-        if (n === 6) return '3rd Place'
-        if (n === 5) return 'Semi-Final'
-        if (n === 4) return 'Quarter-Final'
-        if (n === 3) return 'Round of 16'
-        if (n === 2) return 'Round of 32'
-        return `Round ${n}`
-      }
-      const seen = new Map()
-      this.tabMatches.forEach(m => {
-        if (m.groupId && !seen.has(`g:${m.groupId}`))
-          seen.set(`g:${m.groupId}`, { key: `g:${m.groupId}`, label: m.groupName })
-        else if (!m.groupId && m.roundNumber && !seen.has(`r:${m.roundNumber}`))
-          seen.set(`r:${m.roundNumber}`, { key: `r:${m.roundNumber}`, label: roundLabel(m.roundNumber) })
-      })
-      if (seen.size <= 1) return []
-      const groups = [...seen.values()].filter(f => f.key.startsWith('g:')).sort((a, b) => a.label.localeCompare(b.label))
-      const rounds = [...seen.values()].filter(f => f.key.startsWith('r:')).sort((a, b) => Number(a.key.slice(2)) - Number(b.key.slice(2)))
-      return [{ key: null, label: 'All' }, ...groups, ...rounds]
+      return buildGroupFilters(this.tabMatches)
     },
   },
 
@@ -308,44 +327,52 @@ export default {
       this.selectedTab = tabName
       this.selectedGroup = null
     },
-    applyGroupFilter(matches) {
-      if (!this.selectedGroup) return matches
-      if (this.selectedGroup.startsWith('g:')) {
-        const id = this.selectedGroup.slice(2)
-        return matches.filter(m => String(m.groupId) === id)
-      }
-      if (this.selectedGroup.startsWith('r:')) {
-        const num = Number(this.selectedGroup.slice(2))
-        return matches.filter(m => !m.groupId && m.roundNumber === num)
-      }
-      return matches
-    },
     ongoingMatches() {
-      return [{
-        matches: groupBy(
-          this.applyGroupFilter(this.matches.filter(m => m.status === 'started'))
-            .sort((m1, m2) => new Date(m1.kickoffTime) - new Date(m2.kickoffTime)),
-          m => formatDate(new Date(m.kickoffTime))
-        ),
-      }]
+      return [
+        {
+          matches: groupBy(
+            applyGroupFilter(
+              this.matches.filter(m => m.status === 'started'),
+              this.selectedGroup
+            ).sort(
+              (m1, m2) => new Date(m1.kickoffTime) - new Date(m2.kickoffTime)
+            ),
+            m => formatDate(new Date(m.kickoffTime))
+          ),
+        },
+      ]
     },
     pastMatches() {
-      return [{
-        matches: groupBy(
-          this.applyGroupFilter(this.matches.filter(m => m.status === 'finished'))
-            .sort((m1, m2) => new Date(m2.kickoffTime) - new Date(m1.kickoffTime)),
-          m => formatDate(new Date(m.kickoffTime))
-        ),
-      }]
+      return [
+        {
+          matches: groupBy(
+            applyGroupFilter(
+              this.matches.filter(m => m.status === 'finished'),
+              this.selectedGroup
+            ).sort(
+              (m1, m2) => new Date(m2.kickoffTime) - new Date(m1.kickoffTime)
+            ),
+            m => formatDate(new Date(m.kickoffTime))
+          ),
+        },
+      ]
     },
     upcomingMatches() {
-      return [{
-        matches: groupBy(
-          this.applyGroupFilter(this.matches.filter(m => m.status === 'upcoming' && 'prediction' in m))
-            .sort((m1, m2) => new Date(m1.kickoffTime) - new Date(m2.kickoffTime)),
-          m => formatDate(new Date(m.kickoffTime))
-        ),
-      }]
+      return [
+        {
+          matches: groupBy(
+            applyGroupFilter(
+              this.matches.filter(
+                m => m.status === 'upcoming' && 'prediction' in m
+              ),
+              this.selectedGroup
+            ).sort(
+              (m1, m2) => new Date(m1.kickoffTime) - new Date(m2.kickoffTime)
+            ),
+            m => formatDate(new Date(m.kickoffTime))
+          ),
+        },
+      ]
     },
     getTimeLeftForPrediction() {
       const now = new Date()
@@ -378,6 +405,8 @@ export default {
 .scrollbar-hide {
   -ms-overflow-style: none;
   scrollbar-width: none;
-  &::-webkit-scrollbar { display: none; }
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 </style>

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -24,14 +24,7 @@
       <!-- Has unpredicted matches -->
       <div
         v-if="nextMissingMatch"
-        class="rounded-2xl overflow-hidden shadow-xl"
-        style="
-          background: linear-gradient(
-            135deg,
-            rgba(255, 255, 255, 0.92),
-            rgba(255, 255, 255, 0.78)
-          );
-        "
+        class="rounded-2xl overflow-hidden shadow-xl card-gradient"
       >
         <div class="px-5 pt-4 pb-3">
           <div class="flex items-stretch justify-between gap-3">
@@ -158,7 +151,7 @@
       <div class="flex gap-2 w-max">
         <button
           v-for="filter in groupFilters"
-          :key="filter.key"
+          :key="filter.key === null ? '__all__' : filter.key"
           @click="selectedGroup = filter.key"
           class="py-1 px-3 rounded-full text-xs font-semibold transition-all duration-200 focus:outline-none whitespace-nowrap"
           :class="
@@ -390,6 +383,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.card-gradient {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.92),
+    rgba(255, 255, 255, 0.78)
+  );
+}
 .bg-tab {
   background-color: rgba(255, 255, 255, 0.2);
 }

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -63,7 +63,12 @@
                   fade
                   class="mr-1 text-red-400"
                 />
-                {{ formatDuration(timeLeftForPrediction) }} till kickoff
+                <BaseIcon
+                  v-else
+                  name="stopwatch"
+                  class="mr-1 text-gray-500"
+                />
+                {{ formatDuration(timeLeftForPrediction) }}
               </p>
             </div>
           </div>

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -63,11 +63,7 @@
                   fade
                   class="mr-1 text-red-400"
                 />
-                <BaseIcon
-                  v-else
-                  name="stopwatch"
-                  class="mr-1 text-gray-500"
-                />
+                <BaseIcon v-else name="stopwatch" class="mr-1 text-gray-500" />
                 {{ formatDuration(timeLeftForPrediction) }}
               </p>
             </div>

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -127,6 +127,23 @@
       </div>
     </div>
 
+    <!-- ─── Group filter chips ─── -->
+    <div v-if="groupFilters.length > 1" class="px-4 mt-2 mb-1 overflow-x-auto scrollbar-hide">
+      <div class="flex gap-2 w-max">
+        <button
+          v-for="filter in groupFilters"
+          :key="filter.key"
+          @click="selectedGroup = filter.key"
+          class="py-1 px-3 rounded-full text-xs font-semibold transition-all duration-200 focus:outline-none whitespace-nowrap"
+          :class="selectedGroup === filter.key
+            ? 'text-white chip-active'
+            : 'text-white/50 chip-inactive'"
+        >
+          {{ filter.label }}
+        </button>
+      </div>
+    </div>
+
     <!-- ─── Match list ─── -->
     <MatchesGrouping
       v-for="(group, index) in groupedMatches"
@@ -185,6 +202,7 @@ export default {
       },
       selectedTab: 'ongoing',
       tabs: ['ongoing', 'upcoming', 'past'],
+      selectedGroup: null,
       timeLeftForPrediction: null,
     }
   },
@@ -249,6 +267,33 @@ export default {
       if (this.selectedTab === 'ongoing') return this.ongoingMatches()
       return this.upcomingMatches()
     },
+    tabMatches() {
+      if (this.selectedTab === 'ongoing') return this.matches.filter(m => m.status === 'started')
+      if (this.selectedTab === 'past') return this.matches.filter(m => m.status === 'finished')
+      return this.matches.filter(m => m.status === 'upcoming' && 'prediction' in m)
+    },
+    groupFilters() {
+      const roundLabel = n => {
+        if (n >= 7) return 'Final'
+        if (n === 6) return '3rd Place'
+        if (n === 5) return 'Semi-Final'
+        if (n === 4) return 'Quarter-Final'
+        if (n === 3) return 'Round of 16'
+        if (n === 2) return 'Round of 32'
+        return `Round ${n}`
+      }
+      const seen = new Map()
+      this.tabMatches.forEach(m => {
+        if (m.groupId && !seen.has(`g:${m.groupId}`))
+          seen.set(`g:${m.groupId}`, { key: `g:${m.groupId}`, label: m.groupName })
+        else if (!m.groupId && m.roundNumber && !seen.has(`r:${m.roundNumber}`))
+          seen.set(`r:${m.roundNumber}`, { key: `r:${m.roundNumber}`, label: roundLabel(m.roundNumber) })
+      })
+      if (seen.size <= 1) return []
+      const groups = [...seen.values()].filter(f => f.key.startsWith('g:')).sort((a, b) => a.label.localeCompare(b.label))
+      const rounds = [...seen.values()].filter(f => f.key.startsWith('r:')).sort((a, b) => Number(a.key.slice(2)) - Number(b.key.slice(2)))
+      return [{ key: null, label: 'All' }, ...groups, ...rounds]
+    },
   },
 
   methods: {
@@ -260,12 +305,24 @@ export default {
     formatDuration,
     changeTab(tabName) {
       this.selectedTab = tabName
+      this.selectedGroup = null
+    },
+    applyGroupFilter(matches) {
+      if (!this.selectedGroup) return matches
+      if (this.selectedGroup.startsWith('g:')) {
+        const id = this.selectedGroup.slice(2)
+        return matches.filter(m => String(m.groupId) === id)
+      }
+      if (this.selectedGroup.startsWith('r:')) {
+        const num = Number(this.selectedGroup.slice(2))
+        return matches.filter(m => !m.groupId && m.roundNumber === num)
+      }
+      return matches
     },
     ongoingMatches() {
       return [{
         matches: groupBy(
-          this.matches
-            .filter(m => m.status === 'started')
+          this.applyGroupFilter(this.matches.filter(m => m.status === 'started'))
             .sort((m1, m2) => new Date(m1.kickoffTime) - new Date(m2.kickoffTime)),
           m => formatDate(new Date(m.kickoffTime))
         ),
@@ -274,8 +331,7 @@ export default {
     pastMatches() {
       return [{
         matches: groupBy(
-          this.matches
-            .filter(m => m.status === 'finished')
+          this.applyGroupFilter(this.matches.filter(m => m.status === 'finished'))
             .sort((m1, m2) => new Date(m2.kickoffTime) - new Date(m1.kickoffTime)),
           m => formatDate(new Date(m.kickoffTime))
         ),
@@ -284,8 +340,7 @@ export default {
     upcomingMatches() {
       return [{
         matches: groupBy(
-          this.matches
-            .filter(m => m.status === 'upcoming' && 'prediction' in m)
+          this.applyGroupFilter(this.matches.filter(m => m.status === 'upcoming' && 'prediction' in m))
             .sort((m1, m2) => new Date(m1.kickoffTime) - new Date(m2.kickoffTime)),
           m => formatDate(new Date(m.kickoffTime))
         ),
@@ -312,5 +367,16 @@ export default {
 }
 .border-blue {
   border-color: #6690b7;
+}
+.chip-active {
+  background-color: rgba(255, 255, 255, 0.18);
+}
+.chip-inactive {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar { display: none; }
 }
 </style>


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ It needs [this PR from the back-end](https://github.com/dmbf29/predictor-api/pull/147) for the group name ⚠️ ⚠️ ⚠️ 

## Changes
Because our match cards are so big, I was often getting lost in the scrolling around. Also, there are *so many* games this time around. So added a way to filter by group on your predictions and seeing the results.

### Screenshots
Before/After - Predictions
<table>
<tr>
<td>
<img width="355" alt="image" src="https://github.com/user-attachments/assets/7912c01c-d38f-4547-96f2-7f5e4bdbf6c1" />
</td>

<td>
<img width="355"  alt="image" src="https://github.com/user-attachments/assets/285430ac-bc96-4595-888b-2298fbe0c40a" />
</td>
</tr>
</table>

Before/After - Results
<table>
<tr>
<td>
<img width="355" alt="image" src="https://github.com/user-attachments/assets/f54fb4ba-bda8-4a52-af24-90f450c292d3" />
</td>

<td>
<img width="355" alt="image" src="https://github.com/user-attachments/assets/cc1cc480-bfe5-435f-bf3f-5bb374ffe02d" />
</td>
</tr>
</table>
