### PR TITLE
placeholder for leaderboard is now on first kickoff

### DIFF
--- a/src/components/LeaderboardActions.vue
+++ b/src/components/LeaderboardActions.vue
@@ -4,7 +4,7 @@
     <!-- Invite players -->
     <ShareButton
       :password="leaderboard.password"
-      text="Invite players"
+      :text="`Invite to ${leaderboard.name}`"
       icon="user-plus"
       class="action-btn invite-btn rounded-2xl"
     />

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -145,8 +145,11 @@ export default {
     }),
 
     isPreTournament() {
-      if (!this.currentCompetition?.startDate) return false
-      return new Date(this.currentCompetition.startDate) > new Date()
+      if (!this.matches.length) return true
+      const earliest = this.matches.reduce((min, m) =>
+        new Date(m.kickoffTime) < new Date(min.kickoffTime) ? m : min
+      )
+      return new Date(earliest.kickoffTime) > new Date()
     },
 
     showPreTournamentPlaceholder() {

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -145,11 +145,15 @@ export default {
     }),
 
     isPreTournament() {
-      if (!this.matches.length) return true
-      const earliest = this.matches.reduce((min, m) =>
-        new Date(m.kickoffTime) < new Date(min.kickoffTime) ? m : min
-      )
-      return new Date(earliest.kickoffTime) > new Date()
+      const now = Date.now()
+      if (this.matches.length) {
+        const firstKickoff = Math.min(
+          ...this.matches.map(m => new Date(m.kickoffTime).getTime())
+        )
+        return firstKickoff > now
+      }
+      if (!this.currentCompetition?.startDate) return false
+      return new Date(this.currentCompetition.startDate).getTime() > now
     },
 
     showPreTournamentPlaceholder() {


### PR DESCRIPTION
## Changes
Placeholder was originally just on the day. Now it's on the first kickoff time.

### Screenshots
Before/After
<table>
<tr>
<td>
<img width="355" alt="image" src="https://github.com/user-attachments/assets/92b9107a-c156-41f3-806c-84a8eb318924" />

</td>

<td>
<img width="355" alt="image" src="https://github.com/user-attachments/assets/0800513b-be22-4b16-8f60-fcb6f925601f" />
</td>
</tr>
</table>
