### PR TITLE
Added notification of next knockout match along with placeholders of upcoming matches

### DIFF
--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -5,16 +5,36 @@
       borderStyle,
     ]"
   >
-    <!-- Placeholder: teams not yet determined -->
+    <!-- Placeholder: one or both teams not yet determined -->
     <div v-if="isPlaceholder" class="flex justify-evenly items-center py-5 px-3">
-      <div class="w-1/3 flex flex-col items-center gap-1 opacity-40">
+      <PredictionChoiceTeam
+        v-if="match.teamHome"
+        class="w-1/3"
+        options="h-12 w-12"
+        :team="match.teamHome"
+        status="default"
+        :clickable="false"
+        :greyOut="false"
+        :chosen="false"
+      />
+      <div v-else class="w-1/3 flex flex-col items-center gap-1 opacity-40">
         <div class="h-12 w-12 rounded-full bg-white/10 flex items-center justify-center">
           <span class="text-white text-lg font-bold">?</span>
         </div>
         <p class="text-xs text-white">TBD</p>
       </div>
       <p class="w-1/3 text-white/40 text-sm font-semibold">vs</p>
-      <div class="w-1/3 flex flex-col items-center gap-1 opacity-40">
+      <PredictionChoiceTeam
+        v-if="match.teamAway"
+        class="w-1/3"
+        options="h-12 w-12"
+        :team="match.teamAway"
+        status="default"
+        :clickable="false"
+        :greyOut="false"
+        :chosen="false"
+      />
+      <div v-else class="w-1/3 flex flex-col items-center gap-1 opacity-40">
         <div class="h-12 w-12 rounded-full bg-white/10 flex items-center justify-center">
           <span class="text-white text-lg font-bold">?</span>
         </div>

--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -5,7 +5,24 @@
       borderStyle,
     ]"
   >
-    <div class="flex align justify-evenly items-center">
+    <!-- Placeholder: teams not yet determined -->
+    <div v-if="isPlaceholder" class="flex justify-evenly items-center py-5 px-3">
+      <div class="w-1/3 flex flex-col items-center gap-1 opacity-40">
+        <div class="h-12 w-12 rounded-full bg-white/10 flex items-center justify-center">
+          <span class="text-white text-lg font-bold">?</span>
+        </div>
+        <p class="text-xs text-white">TBD</p>
+      </div>
+      <p class="w-1/3 text-white/40 text-sm font-semibold">vs</p>
+      <div class="w-1/3 flex flex-col items-center gap-1 opacity-40">
+        <div class="h-12 w-12 rounded-full bg-white/10 flex items-center justify-center">
+          <span class="text-white text-lg font-bold">?</span>
+        </div>
+        <p class="text-xs text-white">TBD</p>
+      </div>
+    </div>
+
+    <div v-else class="flex align justify-evenly items-center">
       <PredictionChoiceTeam
         class="w-1/3"
         :options="
@@ -161,8 +178,11 @@ export default {
   },
 
   computed: {
+    isPlaceholder() {
+      return !this.match.teamHome || !this.match.teamAway
+    },
     disabled() {
-      return !this.selectable || this.loading
+      return !this.selectable || this.loading || this.isPlaceholder
     },
     finished() {
       return this.match.status === 'finished'

--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -144,7 +144,12 @@ import PredictionChoiceTeam from './PredictionChoiceTeam'
 import PredictionChoiceDraw from './PredictionChoiceDraw'
 import MatchPredictions from './MatchPredictions'
 import CornerPoints from './CornerPoints'
-import { formatTime, homeTeamWon, awayTeamWon } from '@/utils/helpers'
+import {
+  formatTime,
+  homeTeamWon,
+  awayTeamWon,
+  isPlaceholderMatch,
+} from '@/utils/helpers'
 
 export default {
   components: {
@@ -199,7 +204,7 @@ export default {
 
   computed: {
     isPlaceholder() {
-      return !this.match.teamHome || !this.match.teamAway
+      return isPlaceholderMatch(this.match)
     },
     disabled() {
       return !this.selectable || this.loading || this.isPlaceholder

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -61,6 +61,10 @@ export function formatTime(date) {
   })
 }
 
+export function isPlaceholderMatch(match) {
+  return !match.teamHome || !match.teamAway
+}
+
 export function ordinalize(num) {
   const n = Number(num)
   if (!Number.isFinite(n) || n === 0) return '—'

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -126,6 +126,7 @@ import {
   formatDateTime,
   buildGroupFilters,
   applyGroupFilter,
+  isPlaceholderMatch,
 } from '@/utils/helpers'
 import groupBy from 'lodash/groupBy'
 
@@ -170,8 +171,7 @@ export default {
           m =>
             m.status === 'upcoming' &&
             !('prediction' in m) &&
-            m.teamHome &&
-            m.teamAway
+            !isPlaceholderMatch(m)
         )
         .sort((a, b) => new Date(a.kickoffTime) - new Date(b.kickoffTime))
     }
@@ -199,19 +199,18 @@ export default {
           m =>
             m.status === 'upcoming' &&
             !('prediction' in m) &&
-            m.teamHome &&
-            m.teamAway
+            !isPlaceholderMatch(m)
         )
         .sort((a, b) => new Date(a.kickoffTime) - new Date(b.kickoffTime))
     },
     hasPlaceholderMatches() {
       return this.matches.some(
-        m => m.status === 'upcoming' && (!m.teamHome || !m.teamAway)
+        m => m.status === 'upcoming' && isPlaceholderMatch(m)
       )
     },
     firstPlaceholderKickoff() {
       const first = this.matches
-        .filter(m => m.status === 'upcoming' && (!m.teamHome || !m.teamAway))
+        .filter(m => m.status === 'upcoming' && isPlaceholderMatch(m))
         .sort((a, b) => new Date(a.kickoffTime) - new Date(b.kickoffTime))[0]
       return first ? formatDateTime(first.kickoffTime) : null
     },
@@ -222,7 +221,7 @@ export default {
       return this.matches.some(
         m =>
           m.status === 'upcoming' &&
-          ('prediction' in m || !m.teamHome || !m.teamAway)
+          ('prediction' in m || isPlaceholderMatch(m))
       )
     },
     groupedMatches() {
@@ -238,7 +237,7 @@ export default {
       return this.matches.filter(
         m =>
           m.status === 'upcoming' &&
-          ('prediction' in m || !m.teamHome || !m.teamAway)
+          ('prediction' in m || isPlaceholderMatch(m))
       )
     },
     groupFilters() {
@@ -297,7 +296,7 @@ export default {
               this.matches.filter(
                 m =>
                   m.status === 'upcoming' &&
-                  ('prediction' in m || !m.teamHome || !m.teamAway)
+                  ('prediction' in m || isPlaceholderMatch(m))
               ),
               this.selectedGroup
             ).sort(

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -205,20 +205,24 @@ export default {
         .sort((a, b) => new Date(a.kickoffTime) - new Date(b.kickoffTime))
     },
     hasPlaceholderMatches() {
-      return this.matches.some(m => m.status === 'upcoming' && !m.teamHome)
+      return this.matches.some(
+        m => m.status === 'upcoming' && (!m.teamHome || !m.teamAway)
+      )
     },
     firstPlaceholderKickoff() {
       const first = this.matches
-        .filter(m => m.status === 'upcoming' && !m.teamHome)
+        .filter(m => m.status === 'upcoming' && (!m.teamHome || !m.teamAway))
         .sort((a, b) => new Date(a.kickoffTime) - new Date(b.kickoffTime))[0]
-      return first ? formatDateTime(new Date(first.kickoffTime)) : null
+      return first ? formatDateTime(first.kickoffTime) : null
     },
     hasPastMatches() {
       return this.matches.some(m => m.status === 'finished')
     },
     hasUpcomingPredictions() {
       return this.matches.some(
-        m => m.status === 'upcoming' && ('prediction' in m || !m.teamHome)
+        m =>
+          m.status === 'upcoming' &&
+          ('prediction' in m || !m.teamHome || !m.teamAway)
       )
     },
     groupedMatches() {
@@ -232,7 +236,9 @@ export default {
       if (this.selectedTab === 'past')
         return this.matches.filter(m => m.status === 'finished')
       return this.matches.filter(
-        m => m.status === 'upcoming' && ('prediction' in m || !m.teamHome)
+        m =>
+          m.status === 'upcoming' &&
+          ('prediction' in m || !m.teamHome || !m.teamAway)
       )
     },
     groupFilters() {

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -296,7 +296,8 @@ export default {
             applyGroupFilter(
               this.matches.filter(
                 m =>
-                  m.status === 'upcoming' && ('prediction' in m || !m.teamHome)
+                  m.status === 'upcoming' &&
+                  ('prediction' in m || !m.teamHome || !m.teamAway)
               ),
               this.selectedGroup
             ).sort(

--- a/src/views/Predictions.vue
+++ b/src/views/Predictions.vue
@@ -33,6 +33,18 @@
       </div>
     </div>
 
+    <!-- ─── Placeholder match notice ─── -->
+    <div
+      v-if="!userId && hasPlaceholderMatches && !pendingMatches.length"
+      class="mx-4 mb-4 px-4 py-3 rounded-xl text-xs text-center placeholder-notice"
+    >
+      <p><strong>All predictions made!</strong></p>
+      <p class="mt-0.5">
+        The next prediction opens when the teams are confirmed. Check back
+        before <span class="text-white/80">{{ firstPlaceholderKickoff }}</span>.
+      </p>
+    </div>
+
     <!-- ─── Tabs ─── -->
     <div class="px-4 mb-1">
       <div
@@ -111,6 +123,7 @@ import { mapGetters, mapActions } from 'vuex'
 import { authComputed } from '@/store/helpers'
 import {
   formatDate,
+  formatDateTime,
   buildGroupFilters,
   applyGroupFilter,
 } from '@/utils/helpers'
@@ -153,7 +166,13 @@ export default {
     const matches = await this.fetchMatches({ userId: this.userId })
     if (!this.userId) {
       this.pendingSnapshot = matches
-        .filter(m => m.status === 'upcoming' && !('prediction' in m))
+        .filter(
+          m =>
+            m.status === 'upcoming' &&
+            !('prediction' in m) &&
+            m.teamHome &&
+            m.teamAway
+        )
         .sort((a, b) => new Date(a.kickoffTime) - new Date(b.kickoffTime))
     }
     if (Object.keys(this.ongoingMatches()[0].matches).length === 0) {
@@ -176,15 +195,30 @@ export default {
     pendingMatches() {
       if (this.pendingSnapshot !== null) return this.pendingSnapshot
       return this.matches
-        .filter(m => m.status === 'upcoming' && !('prediction' in m))
+        .filter(
+          m =>
+            m.status === 'upcoming' &&
+            !('prediction' in m) &&
+            m.teamHome &&
+            m.teamAway
+        )
         .sort((a, b) => new Date(a.kickoffTime) - new Date(b.kickoffTime))
+    },
+    hasPlaceholderMatches() {
+      return this.matches.some(m => m.status === 'upcoming' && !m.teamHome)
+    },
+    firstPlaceholderKickoff() {
+      const first = this.matches
+        .filter(m => m.status === 'upcoming' && !m.teamHome)
+        .sort((a, b) => new Date(a.kickoffTime) - new Date(b.kickoffTime))[0]
+      return first ? formatDateTime(new Date(first.kickoffTime)) : null
     },
     hasPastMatches() {
       return this.matches.some(m => m.status === 'finished')
     },
     hasUpcomingPredictions() {
       return this.matches.some(
-        m => m.status === 'upcoming' && 'prediction' in m
+        m => m.status === 'upcoming' && ('prediction' in m || !m.teamHome)
       )
     },
     groupedMatches() {
@@ -198,7 +232,7 @@ export default {
       if (this.selectedTab === 'past')
         return this.matches.filter(m => m.status === 'finished')
       return this.matches.filter(
-        m => m.status === 'upcoming' && 'prediction' in m
+        m => m.status === 'upcoming' && ('prediction' in m || !m.teamHome)
       )
     },
     groupFilters() {
@@ -255,7 +289,8 @@ export default {
           matches: groupBy(
             applyGroupFilter(
               this.matches.filter(
-                m => m.status === 'upcoming' && 'prediction' in m
+                m =>
+                  m.status === 'upcoming' && ('prediction' in m || !m.teamHome)
               ),
               this.selectedGroup
             ).sort(
@@ -285,6 +320,11 @@ export default {
   box-shadow: 0 0 24px rgba(12, 245, 116, 0.2),
     0 0 60px rgba(12, 245, 116, 0.08);
   background: rgba(12, 245, 116, 0.04);
+}
+.placeholder-notice {
+  color: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 .scrollbar-hide {
   -ms-overflow-style: none;


### PR DESCRIPTION
## Changes
I though it was a bit "mysterious" that we never told the users that there will be more predictions that need to be made. Nor _when_ theses matches take place. 
So I added a small notification to inform. Also placeholder matches at the very bottom of the "upcoming" so that when i gets close, the users can see when the games are.

⚠️⚠️⚠️ This PR [needs the back-end PR first](https://github.com/dmbf29/predictor-api/pull/154) ⚠️⚠️⚠️

### Screenshots
Before/After
<table>
<tr>
<td>
<img width="355" height="362" alt="image" src="https://github.com/user-attachments/assets/7d483867-30a7-48fb-a442-e4d1d43b3aa7" />
</td>

<td>
<img width="355" height="447" alt="image" src="https://github.com/user-attachments/assets/1029b17f-7647-4154-b158-8ac157eedc13" />
</td>
</tr>
</table>


Before/After
<table>
<tr>
<td>
<img width="355" height="768" alt="image" src="https://github.com/user-attachments/assets/5cdda39f-55dc-4647-ad50-ec863704ed7a" />
</td>

<td>
<img width="355" height="769" alt="image" src="https://github.com/user-attachments/assets/44176844-6ac9-4f08-88a6-762a2ce8d31e" />
</td>
</tr>
</table>
?

