### PR TITLE
fixed caching issue

### DIFF
--- a/src/store/modules/users.js
+++ b/src/store/modules/users.js
@@ -20,22 +20,16 @@ export const mutations = {
 
 export const actions = {
   fetchUser({ commit, state, rootState }, { userId, competitionId }) {
-    // 1. Check if we already have the user as a current user.
-    const { currentUser } = rootState.auth
     const { currentCompetitionId } = rootState.competitions
     competitionId = competitionId || currentCompetitionId
-    if (currentUser && currentUser.id === userId) {
-      return Promise.resolve(currentUser)
-    }
 
-    // 2. Check if we've already fetched and cached the user.
+    // Check if we've already fetched and cached the user this session.
     const matchedUser = state.cached.find(user => user.id === userId)
     if (matchedUser) {
       return Promise.resolve(matchedUser)
     }
 
-    // 3. Fetch the user from the API and cache it in case
-    //    we need it again in the future.
+    // Fetch fresh from the API and cache it.
     return UsersRepository.getUser(userId, { competitionId }).then(response => {
       const user = response.data
       commit('CACHE_USER', user)


### PR DESCRIPTION
## Changes
fetchUser short-circuits when the requested user is the current user — it returns the currentUser directly from the Vuex store, which was loaded from localStorage at app start. On the phone, that localStorage still has the old photo from before you changed it on desktop.

The fix is to remove that short-circuit so it always hits the API (the in-session cached array still prevents redundant calls).

The currentUser in Vuex is seeded from localStorage at startup — it's a snapshot from the last login, so it could be stale across devices. Now on a fresh session (empty cached array), fetchUser will always hit the API to get the latest photo. Once fetched, it's cached in-memory so navigating around within the same session stays efficient.
