### PR TITLE
scores were hard to read before, now shadowed white

### DIFF
--- a/src/components/PredictionChoiceDraw.vue
+++ b/src/components/PredictionChoiceDraw.vue
@@ -56,6 +56,8 @@ export default {
         return 'draw-selected'
       } else if (this.status === 'correct' || this.status === 'wrong') {
         return `text-white prediction-${this.status} border-prediction-${this.status} border-4`
+      } else if (this.status === 'actual') {
+        return 'border-2 bg-gray-500/50 text-white font-bold shadow-inner-md'
       }
       return 'border-2 bg-gray-500 text-white/50 shadow-inner-md'
     },

--- a/src/components/ResultCard.vue
+++ b/src/components/ResultCard.vue
@@ -187,6 +187,7 @@ export default {
       if (this.match.prediction?.choice === choice) {
         return this.correctPrediction ? 'correct' : 'wrong'
       }
+      if (this.matchResult === choice) return 'actual'
       return 'default'
     },
     formatTime,

--- a/src/components/TeamBadge.vue
+++ b/src/components/TeamBadge.vue
@@ -54,13 +54,6 @@ export default {
     0 0 14px 5px #fffc
 }
 
-.text-glow {
-  text-shadow: -0.07em -0.07em 0.04em #fffc, 0 -0.07em 0.04em #fffc,
-    0.07em -0.07em 0.04em #fffc, 0.07em 0 0.04em #fffc,
-    0.07em 0.07em 0.04em #fffc, 0 0.07em 0.04em #fffc,
-    -0.07em 0.07em 0.04em #fffc, -0.07em 0 0.04em #fffc;
-}
-
 .score-badge {
   font-size: 2.25rem;
   font-weight: 700;

--- a/src/components/TeamBadge.vue
+++ b/src/components/TeamBadge.vue
@@ -7,9 +7,9 @@
     ]"
     :style="`background-image: url(${flag}); background-size: cover; background-position: center;`"
   >
-    <p v-if="psScore" class="score-badge select-none">
-      {{ etScore }}<small>({{ psScore }})</small>
-    </p>
+    <p v-if="psScore" class="score-badge select-none"
+      >{{ etScore }}<small>({{ psScore }})</small></p
+    >
     <p v-else-if="etScore" class="score-badge select-none">{{ etScore }}</p>
     <p v-else class="score-badge select-none">{{ score }}</p>
   </div>

--- a/src/components/TeamBadge.vue
+++ b/src/components/TeamBadge.vue
@@ -7,9 +7,11 @@
     ]"
     :style="`background-image: url(${flag}); background-size: cover; background-position: center;`"
   >
-    <p v-if="psScore" class="text-glow text-4xl select-none">{{ etScore }}<small>({{ psScore }})</small></p>
-    <p v-else-if="etScore" class="text-glow text-4xl select-none">{{ etScore }}</p>
-    <p v-else class="text-glow text-4xl select-none">{{ score }}</p>
+    <p v-if="psScore" class="score-badge select-none">
+      {{ etScore }}<small>({{ psScore }})</small>
+    </p>
+    <p v-else-if="etScore" class="score-badge select-none">{{ etScore }}</p>
+    <p v-else class="score-badge select-none">{{ score }}</p>
   </div>
 </template>
 
@@ -58,6 +60,21 @@ export default {
     0.07em 0.07em 0.04em #fffc, 0 0.07em 0.04em #fffc,
     -0.07em 0.07em 0.04em #fffc, -0.07em 0 0.04em #fffc;
 }
+
+.score-badge {
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: white;
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 50%;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.8), 0 0 8px rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
 small {
   font-size: 0.5em;
 }


### PR DESCRIPTION
## Changes
scores were hard to read before, now shadowed white

### Screenshots
Before/After
<table>
<tr>
<td>
<img width="355"  alt="image" src="https://github.com/user-attachments/assets/b4a5c357-d3f9-40cd-91a2-53eb0a116997" />
</td>

<td>
<img width="355"  alt="image" src="https://github.com/user-attachments/assets/4ea3ac46-1662-4963-9659-a678c75ba447" />
</td>
</tr>
</table>
