### PR TITLE
Added stat Cards

### DIFF
--- a/src/components/LeaderboardRanking.vue
+++ b/src/components/LeaderboardRanking.vue
@@ -29,36 +29,11 @@
         </div>
 
         <!-- Avatar -->
-        <div
-          class="flex-shrink-0 rounded-full overflow-hidden border-2 border-white shadow w-9 h-9"
-        >
-          <img
-            v-if="isImageUrl(ranking.photoKey || ranking.photo_key)"
-            :src="ranking.photoKey || ranking.photo_key"
-            :alt="ranking.name"
-            class="w-full h-full object-cover"
-          />
-          <cld-context
-            v-else-if="ranking.photoKey || ranking.photo_key"
-            :cloudName="cloudName"
-          >
-            <cld-image :publicId="ranking.photoKey || ranking.photo_key">
-              <cld-transformation
-                width="100"
-                height="100"
-                gravity="face"
-                radius="max"
-                crop="fill"
-              />
-            </cld-image>
-          </cld-context>
-          <img
-            v-else
-            :src="require('../assets/player.png')"
-            :alt="ranking.name"
-            class="w-full h-full object-cover"
-          />
-        </div>
+        <UserAvatar
+          :photo-key="ranking.photoKey || ranking.photo_key"
+          :name="ranking.name"
+          :size="36"
+        />
 
         <!-- Name + secondary stat -->
         <div class="flex-1 min-w-0">
@@ -97,14 +72,13 @@
 </template>
 
 <script>
-import { CldContext, CldImage, CldTransformation } from 'cloudinary-vue'
-import { config } from '@/constants'
-import { ordinalize, isImageUrl } from '@/utils/helpers'
+import UserAvatar from '@/components/UserAvatar'
+import { ordinalize } from '@/utils/helpers'
 
 export default {
   name: 'LeaderboardRanking',
 
-  components: { CldContext, CldImage, CldTransformation },
+  components: { UserAvatar },
 
   props: {
     userRankings: {
@@ -129,12 +103,6 @@ export default {
     },
   },
 
-  data() {
-    return {
-      cloudName: config.cloudName,
-    }
-  },
-
   computed: {
     containerPaddingClass() {
       if (this.position === 1) return 'py-4'
@@ -152,21 +120,11 @@ export default {
 
   methods: {
     ordinalize,
-    isImageUrl,
   },
 }
 </script>
 
 <style lang="scss" scoped>
-.ranking-row {
-  :deep(.cld-image),
-  :deep(.cld-image img) {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
-  }
-}
 .bg-ranking-card {
   background: rgba(255, 255, 255, 0.07);
 }

--- a/src/components/LeaderboardRankingsCard.vue
+++ b/src/components/LeaderboardRankingsCard.vue
@@ -105,18 +105,26 @@
 
     <!-- Actions -->
     <LeaderboardActions :leaderboard="leaderboard" class="mt-4" />
+
+    <!-- Stats -->
+    <LeaderboardStats
+      v-if="!isPreTournament"
+      :leaderboard="leaderboard"
+      class="mt-4"
+    />
   </div>
 </template>
 
 <script>
 import LeaderboardRanking from '@/components/LeaderboardRanking'
 import LeaderboardActions from '@/components/LeaderboardActions'
+import LeaderboardStats from '@/components/LeaderboardStats'
 import { mapGetters } from 'vuex'
 
 export default {
   name: 'LeaderboardRankingsCard',
 
-  components: { LeaderboardRanking, LeaderboardActions },
+  components: { LeaderboardRanking, LeaderboardActions, LeaderboardStats },
 
   props: {
     leaderboard: {

--- a/src/components/LeaderboardStats.vue
+++ b/src/components/LeaderboardStats.vue
@@ -1,0 +1,161 @@
+<template>
+  <div v-if="show" class="flex flex-col gap-1.5">
+    <div class="flex items-center gap-3 px-1 py-1">
+      <div class="flex-1 border-t border-white/15" />
+      <span
+        class="text-white/40 text-xs uppercase tracking-widest font-semibold"
+      >
+        Stats
+      </span>
+      <div class="flex-1 border-t border-white/15" />
+    </div>
+    <div class="grid grid-cols-2 gap-1.5">
+      <StatCard
+        v-for="card in cards"
+        :key="card.key"
+        :emoji="card.emoji"
+        :title="card.title"
+        :subtitle="card.subtitle"
+        :users="card.users"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import StatCard from '@/components/StatCard'
+import { computeStats } from '@/utils/statsLogic'
+
+const MIN_MATCHES = 3
+
+const CATALOG = [
+  {
+    key: 'longestCorrectStreak',
+    emoji: '🔮',
+    title: 'The Clairvoyant',
+    sub: s => `${s.value} correct in a row`,
+  },
+  {
+    key: 'longestIncorrectStreak',
+    emoji: '🤡',
+    title: 'The Visionary',
+    sub: s => `${s.value} wrong in a row`,
+  },
+  {
+    key: 'currentCorrectStreak',
+    emoji: '🚀',
+    title: 'The current hot sh*t',
+    sub: s => `${s.value} correct in a row`,
+  },
+  {
+    key: 'currentIncorrectStreak',
+    emoji: '💀',
+    title: 'The current disaster',
+    sub: s => `${s.value} wrong in a row, really?`,
+  },
+  {
+    key: 'theRebel',
+    emoji: '🤘',
+    title: 'The Rebel',
+    sub: s => `beat the crowd ${s.value}×`,
+  },
+  {
+    key: 'theSheep',
+    emoji: '🐑',
+    title: 'The Sheep',
+    sub: s => `followed the crowd ${s.value}×`,
+  },
+  {
+    key: 'soulMates',
+    emoji: '👯',
+    title: 'The Soul Mates',
+    sub: s => `agreed on ${s.value} picks`,
+  },
+  {
+    key: 'nemeses',
+    emoji: '⚔️',
+    title: 'The Arch Rivals',
+    sub: s => `clashed on ${s.value} picks`,
+  },
+  {
+    key: 'bestAccuracy',
+    emoji: '🎯',
+    title: 'The Sharpshooter',
+    sub: s => `${Math.round(s.value * 100)}% on target`,
+  },
+  {
+    key: 'giantSlayer',
+    emoji: '🍀',
+    title: 'The Giant Slayer',
+    sub: s => `against the grain paid off ${s.value}x`,
+  },
+  {
+    key: 'drawWhisperer',
+    emoji: '🤝',
+    title: 'The Draw Whisperer',
+    sub: s => `nailed ${s.value} draws`,
+  },
+  {
+    key: 'mostWrong',
+    emoji: '🐣',
+    title: 'Most wrong',
+    sub: s => `Congratulations, ${s.value} wrong picks. I'm actually amazed`,
+  },
+]
+
+export default {
+  name: 'LeaderboardStats',
+
+  components: { StatCard },
+
+  props: {
+    leaderboard: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  computed: {
+    ...mapGetters({
+      matches: 'matches/matches',
+    }),
+
+    result() {
+      return computeStats(this.leaderboard, this.matches, { maxMembers: 60 })
+    },
+
+    show() {
+      return (
+        this.result.data.finishedCount >= MIN_MATCHES && this.cards.length > 0
+      )
+    },
+
+    cards() {
+      const { data, stats } = this.result
+      const resolve = userId =>
+        data.userIndex.get(userId) || {
+          userId,
+          name: 'Unknown',
+          photoKey: null,
+        }
+
+      // Only cards with a computed winner are shown; the rest are hidden.
+      return CATALOG.filter(card => stats[card.key]).map(card => {
+        const stat = stats[card.key]
+        const users =
+          stat.kind === 'pair'
+            ? stat.userIds.map(resolve)
+            : [resolve(stat.userId)]
+        return {
+          key: card.key,
+          emoji: card.emoji,
+          title: card.title,
+          subtitle: card.sub(stat),
+          users,
+        }
+      })
+    },
+  },
+}
+</script>

--- a/src/components/LeaderboardStats.vue
+++ b/src/components/LeaderboardStats.vue
@@ -39,20 +39,20 @@ const CATALOG = [
   {
     key: 'longestIncorrectStreak',
     emoji: '🤡',
-    title: 'The Visionary',
+    title: 'The "Visionary"',
     sub: s => `${s.value} wrong in a row`,
   },
   {
     key: 'currentCorrectStreak',
     emoji: '🚀',
     title: 'The current hot sh*t',
-    sub: s => `${s.value} correct in a row`,
+    sub: s => `${s.value} correct in a row,\nsuch a poser`,
   },
   {
     key: 'currentIncorrectStreak',
     emoji: '💀',
     title: 'The current disaster',
-    sub: s => `${s.value} wrong in a row, really?`,
+    sub: s => `${s.value} wrong in a row,\nwow, really?`,
   },
   {
     key: 'theRebel',
@@ -93,13 +93,13 @@ const CATALOG = [
   {
     key: 'drawWhisperer',
     emoji: '🤝',
-    title: 'The Draw Whisperer',
+    title: 'The On the Fence',
     sub: s => `nailed ${s.value} draws`,
   },
   {
     key: 'mostWrong',
-    emoji: '🐣',
-    title: 'Most wrong',
+    emoji: '🦄',
+    title: 'My little Pony',
     sub: s => `Congratulations, ${s.value} wrong picks. I'm actually amazed`,
   },
 ]

--- a/src/components/MatchPredictions.vue
+++ b/src/components/MatchPredictions.vue
@@ -17,23 +17,12 @@
             :to="{ name: 'predictions', query: { userId: user.userId } }"
             class="flex items-center gap-1.5 min-w-0"
           >
-            <div
-              class="flex-shrink-0 w-6 h-6 rounded-full overflow-hidden border-2"
-              :class="chipBorderClass('home', user.userId)"
-            >
-              <img
-                v-if="user.photoKey || user.photo_key"
-                :src="avatarUrl(user.photoKey || user.photo_key)"
-                class="w-full h-full object-cover"
-                :alt="user.name"
-              />
-              <img
-                v-else
-                :src="require('../assets/player.png')"
-                class="w-full h-full object-cover"
-                :alt="user.name"
-              />
-            </div>
+            <UserAvatar
+              :photo-key="user.photoKey || user.photo_key"
+              :name="user.name"
+              :size="24"
+              :border-class="`border-2 ${chipBorderClass('home', user.userId)}`"
+            />
             <span
               class="text-xs truncate leading-tight text-white/80"
               :class="isCurrentUser(user.userId) ? 'font-bold' : 'font-medium'"
@@ -57,23 +46,12 @@
             :key="user.userId"
             class="flex items-center gap-1.5 min-w-0"
           >
-            <div
-              class="flex-shrink-0 w-6 h-6 rounded-full overflow-hidden border-2"
-              :class="chipBorderClass('draw', user.userId)"
-            >
-              <img
-                v-if="user.photoKey || user.photo_key"
-                :src="avatarUrl(user.photoKey || user.photo_key)"
-                class="w-full h-full object-cover"
-                :alt="user.name"
-              />
-              <img
-                v-else
-                :src="require('../assets/player.png')"
-                class="w-full h-full object-cover"
-                :alt="user.name"
-              />
-            </div>
+            <UserAvatar
+              :photo-key="user.photoKey || user.photo_key"
+              :name="user.name"
+              :size="24"
+              :border-class="`border-2 ${chipBorderClass('draw', user.userId)}`"
+            />
             <span
               class="text-xs truncate leading-tight text-white/80"
               :class="isCurrentUser(user.userId) ? 'font-bold' : 'font-medium'"
@@ -97,23 +75,12 @@
             :key="user.userId"
             class="flex items-center gap-1.5 min-w-0"
           >
-            <div
-              class="flex-shrink-0 w-6 h-6 rounded-full overflow-hidden border-2"
-              :class="chipBorderClass('away', user.userId)"
-            >
-              <img
-                v-if="user.photoKey || user.photo_key"
-                :src="avatarUrl(user.photoKey || user.photo_key)"
-                class="w-full h-full object-cover"
-                :alt="user.name"
-              />
-              <img
-                v-else
-                :src="require('../assets/player.png')"
-                class="w-full h-full object-cover"
-                :alt="user.name"
-              />
-            </div>
+            <UserAvatar
+              :photo-key="user.photoKey || user.photo_key"
+              :name="user.name"
+              :size="24"
+              :border-class="`border-2 ${chipBorderClass('away', user.userId)}`"
+            />
             <span
               class="text-xs truncate leading-tight text-white/80"
               :class="isCurrentUser(user.userId) ? 'font-bold' : 'font-medium'"
@@ -141,13 +108,12 @@
 
 <script>
 import MatchPredictionsBar from '@/components/MatchPredictionsBar'
-import { config } from '@/constants'
-import { isImageUrl } from '@/utils/helpers'
+import UserAvatar from '@/components/UserAvatar'
 
 export default {
   name: 'MatchPredictions',
 
-  components: { MatchPredictionsBar },
+  components: { MatchPredictionsBar, UserAvatar },
 
   props: {
     match: {
@@ -200,12 +166,6 @@ export default {
       if (live) return 'text-white/70'
       if (winning) return 'text-prediction-correct'
       return 'text-prediction-wrong'
-    },
-
-    // Build a Cloudinary thumbnail URL directly (avoids verbose CldContext wrapper for small images)
-    avatarUrl(photoKey) {
-      if (isImageUrl(photoKey)) return photoKey
-      return `https://res.cloudinary.com/${config.cloudName}/image/upload/w_56,h_56,c_fill,g_face,r_max/${photoKey}`
     },
   },
 }

--- a/src/components/StatCard.vue
+++ b/src/components/StatCard.vue
@@ -1,0 +1,70 @@
+<template>
+  <div
+    class="bg-ranking-card rounded-2xl shadow-sm px-3 py-4 flex flex-col items-center text-center gap-1.5"
+  >
+    <span class="text-4xl leading-none">{{ emoji }}</span>
+
+    <p
+      class="text-white text-xs uppercase tracking-wide font-semibold leading-tight"
+    >
+      {{ title }}
+    </p>
+
+    <div class="flex items-center justify-center mt-2.5">
+      <UserAvatar
+        v-for="(user, index) in users"
+        :key="user.userId"
+        :photo-key="user.photoKey"
+        :name="user.name"
+        :size="36"
+        :class="index > 0 ? '-ml-2' : ''"
+      />
+    </div>
+
+    <p class="text-white/90 text-xs font-medium truncate max-w-full">
+      {{ names }}
+    </p>
+    <p class="text-white/50 text-xs leading-snug">{{ subtitle }}</p>
+  </div>
+</template>
+
+<script>
+import UserAvatar from '@/components/UserAvatar'
+
+export default {
+  name: 'StatCard',
+
+  components: { UserAvatar },
+
+  props: {
+    emoji: {
+      type: String,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    subtitle: {
+      type: String,
+      default: '',
+    },
+    users: {
+      type: Array,
+      default: () => [],
+    },
+  },
+
+  computed: {
+    names() {
+      return this.users.map(user => user.name).join(' & ')
+    },
+  },
+}
+</script>
+
+<style scoped>
+.bg-ranking-card {
+  background: rgba(255, 255, 255, 0.07);
+}
+</style>

--- a/src/components/StatCard.vue
+++ b/src/components/StatCard.vue
@@ -12,19 +12,20 @@
 
     <div class="flex items-center justify-center mt-2.5">
       <UserAvatar
-        v-for="(user, index) in users"
+        v-for="user in users"
         :key="user.userId"
         :photo-key="user.photoKey"
         :name="user.name"
         :size="36"
-        :class="index > 0 ? '-ml-2' : ''"
       />
     </div>
 
     <p class="text-white/90 text-xs font-medium truncate max-w-full">
       {{ names }}
     </p>
-    <p class="text-white/50 text-xs leading-snug">{{ subtitle }}</p>
+    <p class="text-white/50 text-xs leading-snug whitespace-pre-line">
+      {{ subtitle }}
+    </p>
   </div>
 </template>
 

--- a/src/components/UserAvatar.vue
+++ b/src/components/UserAvatar.vue
@@ -1,0 +1,46 @@
+<template>
+  <div
+    class="user-avatar flex-shrink-0 rounded-full overflow-hidden"
+    :class="borderClass"
+    :style="{ width: `${size}px`, height: `${size}px` }"
+  >
+    <img :src="src" :alt="name" class="w-full h-full object-cover" />
+  </div>
+</template>
+
+<script>
+import { config } from '@/constants'
+import { isImageUrl } from '@/utils/helpers'
+
+export default {
+  name: 'UserAvatar',
+
+  props: {
+    photoKey: {
+      type: String,
+      default: null,
+    },
+    name: {
+      type: String,
+      default: '',
+    },
+    size: {
+      type: Number,
+      default: 36,
+    },
+    borderClass: {
+      type: String,
+      default: 'border-2 border-white shadow',
+    },
+  },
+
+  computed: {
+    src() {
+      if (!this.photoKey) return require('../assets/player.png')
+      if (isImageUrl(this.photoKey)) return this.photoKey
+      const px = this.size * 2
+      return `https://res.cloudinary.com/${config.cloudName}/image/upload/w_${px},h_${px},c_fill,g_face,r_max/${this.photoKey}`
+    },
+  },
+}
+</script>

--- a/src/utils/statsLogic.js
+++ b/src/utils/statsLogic.js
@@ -2,6 +2,8 @@ import { homeTeamWon, awayTeamWon, isPlaceholderMatch } from '@/utils/helpers'
 
 const CHOICES = ['home', 'away', 'draw']
 
+const MIN_PREDICTIONS = 5
+
 export const matchOutcome = match => {
   if (!match || match.status !== 'finished') return null
   if (isPlaceholderMatch(match)) return null
@@ -91,6 +93,14 @@ const aggregateCache = new WeakMap()
 const userAggregates = data => {
   if (aggregateCache.has(data)) return aggregateCache.get(data)
 
+  // non-predictors get skipped in calculations
+  const predictors = new Set()
+  data.matchStats.forEach(stat => {
+    stat.picks.forEach((_choice, userId) => {
+      if (data.userIndex.has(userId)) predictors.add(userId)
+    })
+  })
+
   const aggregates = new Map()
   const ensure = userId => {
     if (!aggregates.has(userId)) {
@@ -120,7 +130,7 @@ const userAggregates = data => {
 
   data.matchStats.forEach(stat => {
     // no skips, calculates consecutive only
-    data.userIndex.forEach((_info, userId) => {
+    predictors.forEach(userId => {
       const playerStats = ensure(userId)
       const choice = stat.picks.get(userId)
       if (choice === undefined) {
@@ -206,7 +216,7 @@ const singleResult = (winner, valueOf) =>
 
 export const longestCorrectStreak = data => {
   const candidates = [...userAggregates(data).values()].filter(
-    a => a.bestCorrect >= 3 && a.preds >= 5
+    a => a.bestCorrect >= 3 && a.preds >= MIN_PREDICTIONS
   )
   const winner = bestBy(candidates, [
     (a, b) => b.bestCorrect - a.bestCorrect,
@@ -219,7 +229,7 @@ export const longestCorrectStreak = data => {
 
 export const longestIncorrectStreak = data => {
   const candidates = [...userAggregates(data).values()].filter(
-    a => a.bestWrong >= 3 && a.preds >= 5
+    a => a.bestWrong >= 3 && a.preds >= MIN_PREDICTIONS
   )
   const winner = bestBy(candidates, [
     (a, b) => b.bestWrong - a.bestWrong,
@@ -232,7 +242,7 @@ export const longestIncorrectStreak = data => {
 
 export const currentCorrectStreak = data => {
   const candidates = [...userAggregates(data).values()].filter(
-    a => a.currentCorrect >= 2 && a.preds >= 5
+    a => a.currentCorrect >= 2 && a.preds >= MIN_PREDICTIONS
   )
   const winner = bestBy(candidates, [
     (a, b) => b.currentCorrect - a.currentCorrect,
@@ -245,7 +255,7 @@ export const currentCorrectStreak = data => {
 
 export const currentIncorrectStreak = data => {
   const candidates = [...userAggregates(data).values()].filter(
-    a => a.currentWrong >= 2 && a.preds >= 5
+    a => a.currentWrong >= 2 && a.preds >= MIN_PREDICTIONS
   )
   const winner = bestBy(candidates, [
     (a, b) => b.currentWrong - a.currentWrong,
@@ -259,7 +269,7 @@ export const currentIncorrectStreak = data => {
 export const mostWrong = data => {
   const wrongCount = a => a.preds - a.correct
   const candidates = [...userAggregates(data).values()].filter(
-    a => a.preds >= 5 && wrongCount(a) >= 3
+    a => wrongCount(a) >= MIN_PREDICTIONS
   )
   const winner = bestBy(candidates, [
     (a, b) => wrongCount(b) - wrongCount(a),
@@ -271,7 +281,7 @@ export const mostWrong = data => {
 
 export const theRebel = data => {
   const candidates = [...userAggregates(data).values()].filter(
-    a => a.againstMajCorrect >= 3 && a.preds >= 5
+    a => a.againstMajCorrect >= 3 && a.preds >= MIN_PREDICTIONS
   )
   const winner = bestBy(candidates, [
     (a, b) => b.againstMajCorrect - a.againstMajCorrect,
@@ -286,7 +296,7 @@ export const theRebel = data => {
 
 export const theSheep = data => {
   const candidates = [...userAggregates(data).values()].filter(
-    a => a.preds >= 5 && a.decided >= 5
+    a => a.preds >= MIN_PREDICTIONS && a.decided >= MIN_PREDICTIONS
   )
   const winner = bestBy(candidates, [
     (a, b) => b.withMajority - a.withMajority,
@@ -298,7 +308,7 @@ export const theSheep = data => {
 
 export const bestAccuracy = data => {
   const candidates = [...userAggregates(data).values()].filter(
-    a => a.preds >= 8
+    a => a.preds >= MIN_PREDICTIONS
   )
   const winner = bestBy(candidates, [
     (a, b) => ratio(b.correct, b.preds) - ratio(a.correct, a.preds),
@@ -362,7 +372,7 @@ const pairwiseExtreme = (data, maxMembers, mode) => {
         }
       })
 
-      if (coPredicted < 8) continue
+      if (coPredicted < MIN_PREDICTIONS) continue
       const value = mode === 'agree' ? agreed : coPredicted - agreed
       candidates.push({
         userIds: [ids[i], ids[j]],

--- a/src/utils/statsLogic.js
+++ b/src/utils/statsLogic.js
@@ -1,0 +1,411 @@
+import { homeTeamWon, awayTeamWon, isPlaceholderMatch } from '@/utils/helpers'
+
+const CHOICES = ['home', 'away', 'draw']
+
+export const matchOutcome = match => {
+  if (!match || match.status !== 'finished') return null
+  if (isPlaceholderMatch(match)) return null
+  if (homeTeamWon(match)) return 'home'
+  if (awayTeamWon(match)) return 'away'
+  return 'draw'
+}
+
+const strictExtreme = (counts, mode) => {
+  const entries = CHOICES.map(choice => [choice, counts[choice]])
+  let best = entries[0]
+  let tie = false
+  for (let index = 1; index < entries.length; index++) {
+    const count = entries[index][1]
+    const better = mode === 'max' ? count > best[1] : count < best[1]
+    if (better) {
+      best = entries[index]
+      tie = false
+    } else if (count === best[1]) {
+      tie = true
+    }
+  }
+  return tie ? null : best[0]
+}
+
+export const buildStatsData = (leaderboard, matches) => {
+  const users = (leaderboard && leaderboard.users) || []
+  const results = (leaderboard && leaderboard.results) || {}
+
+  const userIndex = new Map()
+  users.forEach(user => {
+    const userId = user.userId != null ? user.userId : user.id
+    if (userId == null) return
+    userIndex.set(userId, {
+      userId,
+      name: user.name,
+      photoKey: user.photoKey || user.photo_key || null,
+      points: user.points || 0,
+    })
+  })
+
+  const matchById = new Map()
+  ;(matches || []).forEach(match => matchById.set(match.id, match))
+
+  const matchStats = []
+  Object.keys(results).forEach(key => {
+    const match = matchById.get(key) || matchById.get(Number(key))
+    const outcome = matchOutcome(match)
+    if (!outcome) return
+
+    const choiceArrays = results[key] || {}
+    const picks = new Map()
+    const counts = { home: 0, away: 0, draw: 0 }
+    CHOICES.forEach(choice => {
+      ;(choiceArrays[choice] || []).forEach(userId => {
+        picks.set(userId, choice)
+        counts[choice] += 1
+      })
+    })
+
+    const majority = strictExtreme(counts, 'max')
+    const minorityOutcome = strictExtreme(counts, 'min')
+
+    matchStats.push({
+      matchId: match.id,
+      kickoffTime: match.kickoffTime,
+      outcome,
+      picks,
+      counts,
+      majority,
+      minorityOutcome,
+    })
+  })
+
+  matchStats.sort((a, b) => new Date(a.kickoffTime) - new Date(b.kickoffTime))
+
+  return {
+    userIndex,
+    userIds: [...userIndex.keys()],
+    matchStats,
+    finishedCount: matchStats.length,
+  }
+}
+
+const aggregateCache = new WeakMap()
+
+const userAggregates = data => {
+  if (aggregateCache.has(data)) return aggregateCache.get(data)
+
+  const aggregates = new Map()
+  const ensure = userId => {
+    if (!aggregates.has(userId)) {
+      const info = data.userIndex.get(userId)
+      aggregates.set(userId, {
+        userId,
+        points: (info && info.points) || 0,
+        preds: 0,
+        correct: 0,
+        bestCorrect: 0,
+        curCorrect: 0,
+        bestWrong: 0,
+        curWrong: 0,
+        currentCorrect: 0,
+        currentWrong: 0,
+        drawPicks: 0,
+        correctDraws: 0,
+        decided: 0,
+        withMajority: 0,
+        againstMajAttempts: 0,
+        againstMajCorrect: 0,
+        giantSlayer: 0,
+      })
+    }
+    return aggregates.get(userId)
+  }
+
+  data.matchStats.forEach(stat => {
+    // no skips, calculates consecutive only
+    data.userIndex.forEach((_info, userId) => {
+      const playerStats = ensure(userId)
+      const choice = stat.picks.get(userId)
+      if (choice === undefined) {
+        playerStats.curCorrect = 0
+        playerStats.curWrong = 0
+        return
+      }
+      if (choice === stat.outcome) {
+        playerStats.curCorrect += 1
+        playerStats.curWrong = 0
+      } else {
+        playerStats.curWrong += 1
+        playerStats.curCorrect = 0
+      }
+      if (playerStats.curCorrect > playerStats.bestCorrect)
+        playerStats.bestCorrect = playerStats.curCorrect
+      if (playerStats.curWrong > playerStats.bestWrong)
+        playerStats.bestWrong = playerStats.curWrong
+
+      // Current (still-alive) streak
+      playerStats.currentCorrect = playerStats.curCorrect
+      playerStats.currentWrong = playerStats.curWrong
+    })
+
+    stat.picks.forEach((choice, userId) => {
+      if (!data.userIndex.has(userId)) return
+      const playerStats = ensure(userId)
+      const correct = choice === stat.outcome
+
+      playerStats.preds += 1
+      if (correct) playerStats.correct += 1
+
+      if (choice === 'draw') {
+        playerStats.drawPicks += 1
+        if (correct) playerStats.correctDraws += 1
+      }
+
+      if (stat.majority !== null) {
+        playerStats.decided += 1
+        if (choice === stat.majority) {
+          playerStats.withMajority += 1
+        } else {
+          playerStats.againstMajAttempts += 1
+          if (correct) playerStats.againstMajCorrect += 1
+        }
+      }
+
+      if (
+        stat.minorityOutcome !== null &&
+        stat.outcome === stat.minorityOutcome &&
+        choice === stat.minorityOutcome
+      ) {
+        playerStats.giantSlayer += 1
+      }
+    })
+  })
+
+  aggregateCache.set(data, aggregates)
+  return aggregates
+}
+
+const idCompare = (a, b) => String(a.userId).localeCompare(String(b.userId))
+
+const bestBy = (entries, comparators) => {
+  if (!entries.length) return null
+  return entries.slice().sort((a, b) => {
+    for (let index = 0; index < comparators.length; index++) {
+      const result = comparators[index](a, b)
+      if (result !== 0) return result
+    }
+    return 0
+  })[0]
+}
+
+const ratio = (numerator, denominator) =>
+  denominator ? numerator / denominator : 0
+
+// Wraps a bestBy() winner into the card's single-winner result shape (or null).
+const singleResult = (winner, valueOf) =>
+  winner
+    ? { kind: 'single', userId: winner.userId, value: valueOf(winner) }
+    : null
+
+export const longestCorrectStreak = data => {
+  const candidates = [...userAggregates(data).values()].filter(
+    a => a.bestCorrect >= 3 && a.preds >= 5
+  )
+  const winner = bestBy(candidates, [
+    (a, b) => b.bestCorrect - a.bestCorrect,
+    (a, b) => b.preds - a.preds,
+    (a, b) => b.points - a.points,
+    idCompare,
+  ])
+  return singleResult(winner, w => w.bestCorrect)
+}
+
+export const longestIncorrectStreak = data => {
+  const candidates = [...userAggregates(data).values()].filter(
+    a => a.bestWrong >= 3 && a.preds >= 5
+  )
+  const winner = bestBy(candidates, [
+    (a, b) => b.bestWrong - a.bestWrong,
+    (a, b) => b.preds - a.preds,
+    (a, b) => b.points - a.points,
+    idCompare,
+  ])
+  return singleResult(winner, w => w.bestWrong)
+}
+
+export const currentCorrectStreak = data => {
+  const candidates = [...userAggregates(data).values()].filter(
+    a => a.currentCorrect >= 2 && a.preds >= 5
+  )
+  const winner = bestBy(candidates, [
+    (a, b) => b.currentCorrect - a.currentCorrect,
+    (a, b) => b.bestCorrect - a.bestCorrect,
+    (a, b) => b.points - a.points,
+    idCompare,
+  ])
+  return singleResult(winner, w => w.currentCorrect)
+}
+
+export const currentIncorrectStreak = data => {
+  const candidates = [...userAggregates(data).values()].filter(
+    a => a.currentWrong >= 2 && a.preds >= 5
+  )
+  const winner = bestBy(candidates, [
+    (a, b) => b.currentWrong - a.currentWrong,
+    (a, b) => b.bestWrong - a.bestWrong,
+    (a, b) => b.points - a.points,
+    idCompare,
+  ])
+  return singleResult(winner, w => w.currentWrong)
+}
+
+export const mostWrong = data => {
+  const wrongCount = a => a.preds - a.correct
+  const candidates = [...userAggregates(data).values()].filter(
+    a => a.preds >= 5 && wrongCount(a) >= 3
+  )
+  const winner = bestBy(candidates, [
+    (a, b) => wrongCount(b) - wrongCount(a),
+    (a, b) => ratio(a.correct, a.preds) - ratio(b.correct, b.preds),
+    idCompare,
+  ])
+  return singleResult(winner, wrongCount)
+}
+
+export const theRebel = data => {
+  const candidates = [...userAggregates(data).values()].filter(
+    a => a.againstMajCorrect >= 3 && a.preds >= 5
+  )
+  const winner = bestBy(candidates, [
+    (a, b) => b.againstMajCorrect - a.againstMajCorrect,
+    (a, b) =>
+      ratio(b.againstMajCorrect, b.againstMajAttempts) -
+      ratio(a.againstMajCorrect, a.againstMajAttempts),
+    (a, b) => b.points - a.points,
+    idCompare,
+  ])
+  return singleResult(winner, w => w.againstMajCorrect)
+}
+
+export const theSheep = data => {
+  const candidates = [...userAggregates(data).values()].filter(
+    a => a.preds >= 5 && a.decided >= 5
+  )
+  const winner = bestBy(candidates, [
+    (a, b) => b.withMajority - a.withMajority,
+    (a, b) => b.points - a.points,
+    idCompare,
+  ])
+  return singleResult(winner, w => w.withMajority)
+}
+
+export const bestAccuracy = data => {
+  const candidates = [...userAggregates(data).values()].filter(
+    a => a.preds >= 8
+  )
+  const winner = bestBy(candidates, [
+    (a, b) => ratio(b.correct, b.preds) - ratio(a.correct, a.preds),
+    (a, b) => b.preds - a.preds,
+    idCompare,
+  ])
+  return singleResult(winner, w => ratio(w.correct, w.preds))
+}
+
+export const giantSlayer = data => {
+  const candidates = [...userAggregates(data).values()].filter(
+    a => a.giantSlayer >= 2
+  )
+  const winner = bestBy(candidates, [
+    (a, b) => b.giantSlayer - a.giantSlayer,
+    (a, b) => b.points - a.points,
+    idCompare,
+  ])
+  return singleResult(winner, w => w.giantSlayer)
+}
+
+export const drawWhisperer = data => {
+  const candidates = [...userAggregates(data).values()].filter(
+    a => a.correctDraws >= 2
+  )
+  const winner = bestBy(candidates, [
+    (a, b) => b.correctDraws - a.correctDraws,
+    (a, b) =>
+      ratio(b.correctDraws, b.drawPicks) - ratio(a.correctDraws, a.drawPicks),
+    idCompare,
+  ])
+  return singleResult(winner, w => w.correctDraws)
+}
+
+const pairwiseExtreme = (data, maxMembers, mode) => {
+  const ids = data.userIds
+  if (ids.length > maxMembers) return null
+
+  const pickMaps = new Map()
+  ids.forEach(id => pickMaps.set(id, new Map()))
+  data.matchStats.forEach(stat => {
+    stat.picks.forEach((choice, userId) => {
+      const map = pickMaps.get(userId)
+      if (map) map.set(stat.matchId, choice)
+    })
+  })
+
+  const candidates = []
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      const a = pickMaps.get(ids[i])
+      const b = pickMaps.get(ids[j])
+      const [small, large] = a.size <= b.size ? [a, b] : [b, a]
+
+      let coPredicted = 0
+      let agreed = 0
+      small.forEach((choice, matchId) => {
+        if (large.has(matchId)) {
+          coPredicted += 1
+          if (large.get(matchId) === choice) agreed += 1
+        }
+      })
+
+      if (coPredicted < 8) continue
+      const value = mode === 'agree' ? agreed : coPredicted - agreed
+      candidates.push({
+        userIds: [ids[i], ids[j]],
+        value,
+        ratioValue: ratio(value, coPredicted),
+      })
+    }
+  }
+
+  const winner = bestBy(candidates, [
+    (a, b) => b.value - a.value,
+    (a, b) => b.ratioValue - a.ratioValue,
+    (a, b) => String(a.userIds).localeCompare(String(b.userIds)),
+  ])
+  return winner
+    ? { kind: 'pair', userIds: winner.userIds, value: winner.value }
+    : null
+}
+
+export const soulMates = (data, { maxMembers = 60 } = {}) =>
+  pairwiseExtreme(data, maxMembers, 'agree')
+
+export const nemeses = (data, { maxMembers = 60 } = {}) =>
+  pairwiseExtreme(data, maxMembers, 'disagree')
+
+export const computeStats = (leaderboard, matches, options = {}) => {
+  const data = buildStatsData(leaderboard, matches)
+  const { maxMembers = 60 } = options
+  return {
+    data,
+    stats: {
+      longestCorrectStreak: longestCorrectStreak(data),
+      longestIncorrectStreak: longestIncorrectStreak(data),
+      currentCorrectStreak: currentCorrectStreak(data),
+      currentIncorrectStreak: currentIncorrectStreak(data),
+      mostWrong: mostWrong(data),
+      theRebel: theRebel(data),
+      theSheep: theSheep(data),
+      soulMates: soulMates(data, { maxMembers }),
+      nemeses: nemeses(data, { maxMembers }),
+      bestAccuracy: bestAccuracy(data),
+      giantSlayer: giantSlayer(data),
+      drawWhisperer: drawWhisperer(data),
+    },
+  }
+}


### PR DESCRIPTION
- just an idea to play with the data we have already
- some refactor to re-use useravart
- feature is leadabord agnostic, or should be
- made it flexible and easy to add remove more stats, just need to add the logic yourself 😅
- would be cool if we tracked when people change their picks, or just how many times maybe wanted to add a "The overthinkinker" card lol. 
- These go in "rankingS" tab, under the list of players

<img width="340" height="502" alt="Screenshot 2026-06-18 at 22 48 48" src="https://github.com/user-attachments/assets/621e19b6-d286-4b04-83ec-1eae78bf8307" />
<img width="344" height="492" alt="Screenshot 2026-06-18 at 22 48 53" src="https://github.com/user-attachments/assets/5a3f1363-6575-4edf-b82a-46f221925908" />
