### PR TITLE
fixing extra time score bug

### DIFF
--- a/src/components/TeamBadge.vue
+++ b/src/components/TeamBadge.vue
@@ -7,10 +7,10 @@
     ]"
     :style="`background-image: url(${flag}); background-size: cover; background-position: center;`"
   >
-    <p v-if="psScore" class="score-badge select-none"
+    <p v-if="hasPsScore" class="score-badge select-none"
       >{{ etScore }}<small>({{ psScore }})</small></p
     >
-    <p v-else-if="etScore" class="score-badge select-none">{{ etScore }}</p>
+    <p v-else-if="hasEtScore" class="score-badge select-none">{{ etScore }}</p>
     <p v-else class="score-badge select-none">{{ score }}</p>
   </div>
 </template>
@@ -31,6 +31,12 @@ export default {
   },
 
   computed: {
+    hasEtScore() {
+      return this.etScore !== null && this.etScore !== undefined
+    },
+    hasPsScore() {
+      return this.psScore !== null && this.psScore !== undefined
+    },
     highlight() {
       switch (this.status) {
         case 'correct':


### PR DESCRIPTION
## Changes
TeamBadge.vue picked which score to display using plain truthiness (v-if="psScore", v-else-if="etScore"). A value of 0 is falsy in JS, so when a team's extra-time score is 0, the template skipped it and fell through to the regular-time score instead.

For match 485: team_away_et_score = 0 → treated as "no ET score" → displayed team_away_score = 2 (regular time) instead of 0 (ET). Meanwhile team_home_et_score = 1 is truthy, so it displayed correctly. Net result: home showed its real ET score (1), away showed the wrong score (2) — matching exactly what you saw.

Fix: replaced the truthiness checks with explicit not-null/undefined checks (hasEtScore/hasPsScore computed properties), so a 0 ET score now renders correctly instead of being treated as absent.

This likely affects any other finished match that went to extra time and ended 0 on one side (e.g., a 1-0 ET result) — worth spot-checking those once deployed.

### Screenshots
Before/After
<table>
<tr>
<td>
<img width="340" height="415" alt="image" src="https://github.com/user-attachments/assets/13c81ac7-df3e-44f4-bd3b-3eb1772f7fae" />

</td>

<td>
<img width="340" height="415" alt="image" src="https://github.com/user-attachments/assets/5af53ffd-52b5-454a-acb3-0d47b421b40a" />
</td>
</tr>
</table>
